### PR TITLE
Push CNAME

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The `secrets` and `env` portion of the workflow **must** be configured before th
 | `BUILD_SCRIPT`  | If you require a build script to compile your code prior to pushing it you can add the script here. The Docker container which powers the action runs Node which means `npm` commands are valid. If you're using a static site generator such as Jekyll I'd suggest compiling the code prior to pushing it to your base branch.  | `env` | **No** |
 | `COMMIT_NAME`  | Used to sign the commit, this should be your name. If not provided it will default to `username@users.noreply.github.com`  | `env` | **No** |
 | `COMMIT_EMAIL`  | Used to sign the commit, this should be your email. If not provided it will default to your username. | `env` | **No** |
+| `CNAME`  | If you're using a custom domain, you will need to add the domain name to the `CNAME` environment variable. If you don't do this GitHub will wipe out your domain configuration after each deploy. This value will look something like this: `jamesives.dev`.  | `env` | **No** |
 
 With the action correctly configured you should see something similar to this in your GitHub actions workflow editor.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -65,7 +65,7 @@ echo "Running build scripts... $BUILD_SCRIPT" && \
 eval "$BUILD_SCRIPT" && \
 
 if [ "$CNAME" ]; then
-  echo "Generating a CNAME file in in the $FOLDER directory."
+  echo "Generating a CNAME file in in the $FOLDER directory..."
   echo $CNAME > $FOLDER/CNAME
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,9 +64,15 @@ git checkout "${BASE_BRANCH:-master}" && \
 echo "Running build scripts... $BUILD_SCRIPT" && \
 eval "$BUILD_SCRIPT" && \
 
+if [ "$CNAME" ]; then
+  echo "Generating a CNAME file in in the $FOLDER directory."
+  echo $CNAME > $FOLDER/CNAME
+fi
+
 # Commits the data to Github.
 echo "Deploying to GitHub..." && \
 git add -f $FOLDER && \
+
 git commit -m "Deploying to ${BRANCH} - $(date +"%T")" && \
 git push $REPOSITORY_PATH `git subtree split --prefix $FOLDER master`:$BRANCH --force && \
 echo "Deployment succesful!"


### PR DESCRIPTION
**Description**
> Provide a description of what your changes do.

Kept running into this issue this weekend with Liza's portfolio site. If you deploy via this action with a custom domain, Github will nuke the configuration for the domain as the `CNAME` file is no longer present in the `gh-pages` branch. In order to solve this I've added an additional environment variable called `CNAME` which will add the domain record into the build directory prior to the deploy. This will maintain the GitHub configuration which will solve the issue of pages 404ing after the deploy.

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

* Add a CNAME record, and deploy. If you have a custom domain it will no longer 404 after the deploy. 
