### PR TITLE
Renames ACCESS_TOKEN to GITHUB_TOKEN

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# GitHub Pages Deploy Action :rocket: 
+# GitHub Pages Deploy Action :rocket:
 
 [![View Action](https://img.shields.io/badge/view-action-blue.svg)](https://github.com/marketplace/actions/deploy-to-github-pages) [![Issues](https://img.shields.io/github/issues/JamesIves/github-pages-deploy-action.svg)](https://github.com/JamesIves/github-pages-deploy-action/issues)
 
@@ -15,7 +15,7 @@ action "Deploy to GitHub Pages" {
     BRANCH = "gh-pages"
     FOLDER = "build"
   }
-  secrets = ["ACCESS_TOKEN"]
+  secrets = ["GITHUB_TOKEN"]
 }
 ```
 
@@ -39,7 +39,7 @@ action "Deploy to gh-pages" {
     BUILD_SCRIPT = "npm install && npm run-script build"
     FOLDER = "build"
   }
-  secrets = ["ACCESS_TOKEN"]
+  secrets = ["GITHUB_TOKEN"]
   needs = ["master branch only"]
 }
 ```
@@ -50,7 +50,7 @@ The `secrets` and `env` portion of the workflow **must** be configured before th
 
 | Key  | Value Information | Type | Required |
 | ------------- | ------------- | ------------- | ------------- |
-| `ACCESS_TOKEN`  | In order for GitHub to trigger the rebuild of your page you must provide the action with a GitHub personal access token. You can [learn more about how to generate one here](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line). This **should be stored as a secret.**  | `secrets` | **Yes** |
+| `GITHUB_TOKEN`  | In order for GitHub to trigger the rebuild of your page you must provide the action with a GitHub personal access token. You can [learn more about how to generate one here](https://help.github.com/en/articles/creating-a-personal-access-token-for-the-command-line). This **should be stored as a secret.**  | `secrets` | **Yes** |
 | `BRANCH`  | This is the branch you wish to deploy to, for example `gh-pages` or `docs`.  | `env` | **Yes** |
 | `FOLDER`  | The folder in your repository that you want to deploy. If your build script compiles into a directory named `build` you'd put it here. | `env` | **Yes** |
 | `BASE_BRANCH`  | The base branch of your repository which you'd like to checkout prior to deploying. This defaults to `master`.  | `env` | **No** |

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -l
 
-if [ -z "$ACCESS_TOKEN" ]
+if [ -z "$GITHUB_TOKEN" ]
 then
   echo "You must provide the action with a GitHub Personal Access Token secret in order to deploy."
   exit 1
@@ -41,7 +41,7 @@ git config --global user.email "${COMMIT_EMAIL}" && \
 git config --global user.name "${COMMIT_NAME}" && \
 
 ## Initializes the repository path using the access token.
-REPOSITORY_PATH="https://${ACCESS_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
+REPOSITORY_PATH="https://${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" && \
 
 # Checks to see if the remote exists prior to deploying.
 # If the branch doesn't exist it gets created here as an orphan.


### PR DESCRIPTION
**Description**
Renames `ACCESS_TOKEN` env-variable to `GITHUB_TOKEN`.

As of right now, Github allows you to use the `GITHUB_TOKEN` variable directly from within the workflow without any further configuration so to me it makes sense to name the variable accordingly.

https://developer.github.com/actions/managing-workflows/storing-secrets/#github-token-secret 

WDYT?

**Testing Instructions**
I have setup a workflow at https://github.com/ivoputzer/github-page which uses the fork as of right now.
