### PR TITLE
Don't push if the build fails

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
 
+set -e
+
 if [ -z "$ACCESS_TOKEN" ]
 then
   echo "You must provide the action with a GitHub Personal Access Token secret in order to deploy."


### PR DESCRIPTION
Currently, if the build fails (or some other part of the script), it will happily continue and force push the result to the destination.

Adding `set -e` makes sh terminate the script after any errors