### PR TITLE
Removes the need for COMMIT_NAME and COMMIT_EMAIL

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,6 @@ Below you'll find a description of what each option does.
 | `BASE_BRANCH`  | The base branch of your repository which you'd like to checkout prior to deploying. This defaults to `master`.  | `env` | **No** |
 | `BUILD_SCRIPT`  | If you require a build script to compile your code prior to pushing it you can add the script here. The Docker container which powers the action runs Node which means `npm` commands are valid. If you're using a static site generator such as Jekyll I'd suggest compiling the code prior to pushing it to your base branch.  | `env` | **No** |
 | `CNAME`  | If you're using a [custom domain](https://help.github.com/en/articles/using-a-custom-domain-with-github-pages), you will need to add the domain name to the `CNAME` environment variable. If you don't do this GitHub will wipe out your domain configuration after each deploy. This value will look something like this: `jives.dev`.  | `env` | **No** |
-| `COMMIT_EMAIL`  | Used to sign the commit, this should be your email. If not provided it will default to your username. | `env` | **No** |
-| `COMMIT_NAME`  | Used to sign the commit, this should be your name. If not provided it will default to `username@users.noreply.github.com`  | `env` | **No** |
 
 With the action correctly configured you should see the workflow trigger the deployment under the configured conditions.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,15 @@ case "$FOLDER" in /*|./*)
   exit 1
 esac
 
+# Installs Git.
+apt-get update && \
+apt-get install -y git && \
+apt-get install -y jq && \
+
+# Gets the commit email/name if it exists in the push event payload.
+COMMIT_EMAIL=`jq '.pusher.email' ${GITHUB_EVENT_PATH}`
+COMMIT_NAME=`jq '.pusher.name' ${GITHUB_EVENT_PATH}`
+
 if [ -z "$COMMIT_EMAIL" ]
 then
   COMMIT_EMAIL="${GITHUB_ACTOR}@users.noreply.github.com"
@@ -34,10 +43,6 @@ if [ -z "$COMMIT_NAME" ]
 then
   COMMIT_NAME="${GITHUB_ACTOR}"
 fi
-
-# Installs Git.
-apt-get update && \
-apt-get install -y git && \
 
 # Directs the action to the the Github workspace.
 cd $GITHUB_WORKSPACE && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -36,12 +36,12 @@ COMMIT_NAME=`jq '.pusher.name' ${GITHUB_EVENT_PATH}`
 
 if [ -z "$COMMIT_EMAIL" ]
 then
-  COMMIT_EMAIL="${GITHUB_ACTOR}@users.noreply.github.com"
+  COMMIT_EMAIL="${GITHUB_ACTOR:-github-pages-deploy-action}@users.noreply.github.com"
 fi
 
 if [ -z "$COMMIT_NAME" ]
 then
-  COMMIT_NAME="${GITHUB_ACTOR}"
+  COMMIT_NAME="${GITHUB_ACTOR:-GitHub Pages Deploy Action}"
 fi
 
 # Directs the action to the the Github workspace.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,7 +25,7 @@ case "$FOLDER" in /*|./*)
   exit 1
 esac
 
-# Installs Git.
+# Installs Git and jq.
 apt-get update && \
 apt-get install -y git && \
 apt-get install -y jq && \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,6 +34,7 @@ apt-get install -y jq && \
 COMMIT_EMAIL=`jq '.pusher.email' ${GITHUB_EVENT_PATH}`
 COMMIT_NAME=`jq '.pusher.name' ${GITHUB_EVENT_PATH}`
 
+# If the commit email/name is not found in the event payload then it falls back to the actor.
 if [ -z "$COMMIT_EMAIL" ]
 then
   COMMIT_EMAIL="${GITHUB_ACTOR:-github-pages-deploy-action}@users.noreply.github.com"


### PR DESCRIPTION
**Description**
> Provide a description of what your changes do.

This pull request removes the requirement for `COMMIT_NAME` and `COMMIT_EMAIL`. If the event path payload has the data available it will use it, otherwise it will fall back to the `GITHUB_ACTOR` variable instead. This ensures that commits correctly come from a verified user.

If in the rare case that there's no `GITHUB_ACTOR` available, it will fall back to an email/name that shows it's from this action.

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

Push up a commit, it should work the same before with both a scheduled/unscheduled job.

**Additional Notes**
> Anything else that will help us test the pull request.

`jq` is used to pull the information from the JSON payload. 