### PR TITLE
Quiets the commit logs

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -l
 
+set -e
+
 if [ -z "$ACCESS_TOKEN" ]
 then
   echo "You must provide the action with a GitHub Personal Access Token secret in order to deploy."
@@ -79,5 +81,5 @@ echo "Deploying to GitHub..." && \
 git add -f $FOLDER && \
 
 git commit -m "Deploying to ${BRANCH} - $(date +"%T")" && \
-git push $REPOSITORY_PATH `git subtree split --prefix $FOLDER ${BASE_BRANCH:-master}`:$BRANCH --force && \
+git push $REPOSITORY_PATH `git subtree split --prefix $FOLDER ${BASE_BRANCH:-master}`:$BRANCH --force --quiet && \
 echo "Deployment succesful!"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,5 @@
 #!/bin/sh -l
 
-set -e
-
 if [ -z "$ACCESS_TOKEN" ]
 then
   echo "You must provide the action with a GitHub Personal Access Token secret in order to deploy."

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,8 +78,8 @@ fi
 
 # Commits the data to Github.
 echo "Deploying to GitHub..." && \
-git add -f $FOLDER && \
+git add -f --quiet $FOLDER && \
 
 git commit -m "Deploying to ${BRANCH} - $(date +"%T")" && \
-git push $REPOSITORY_PATH `git subtree split --prefix $FOLDER ${BASE_BRANCH:-master}`:$BRANCH --force --quiet && \
+git push $REPOSITORY_PATH `git subtree split --prefix $FOLDER ${BASE_BRANCH:-master}`:$BRANCH --force && \
 echo "Deployment succesful!"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,6 +80,6 @@ fi
 echo "Deploying to GitHub..." && \
 git add -f $FOLDER && \
 
-git commit -m -q "Deploying to ${BRANCH} - $(date +"%T")" && \
+git commit -m "Deploying to ${BRANCH} - $(date +"%T")" --quiet && \
 git push $REPOSITORY_PATH `git subtree split --prefix $FOLDER ${BASE_BRANCH:-master}`:$BRANCH --force && \
 echo "Deployment succesful!"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -78,8 +78,8 @@ fi
 
 # Commits the data to Github.
 echo "Deploying to GitHub..." && \
-git add -f --quiet $FOLDER && \
+git add -f $FOLDER && \
 
-git commit -m "Deploying to ${BRANCH} - $(date +"%T")" && \
+git commit -m -q "Deploying to ${BRANCH} - $(date +"%T")" && \
 git push $REPOSITORY_PATH `git subtree split --prefix $FOLDER ${BASE_BRANCH:-master}`:$BRANCH --force && \
 echo "Deployment succesful!"


### PR DESCRIPTION
**Description**
> Provide a description of what your changes do.

This pull request sets the `--quiet` flag on the `git commit` command. This resolves an issue where `stdout` was throwing an error because it was logging a ton of changes all at once.

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

This was tested by user @Rangoric in issue #24.
