### PR TITLE
Pusher is undefined in scheduled jobs

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -24,7 +24,15 @@ exports.action = {
     accessToken: core.getInput("ACCESS_TOKEN"),
     branch: core.getInput("BRANCH"),
     baseBranch: core.getInput("BASE_BRANCH") || "master",
-    pusher
+    name: pusher && pusher.name
+        ? pusher.name
+        : process.env.GITHUB_ACTOR
+            ? process.env.GITHUB_ACTOR
+            : "GitHub Pages Deploy Action",
+    email: pusher && pusher.email
+        ? pusher.email
+        : `${process.env.GITHUB_ACTOR ||
+            "github-pages-deploy-action"}@users.noreply.github.com`
 };
 // Repository path used for commits/pushes.
 exports.repositoryPath = `https://${exports.action.accessToken ||

--- a/lib/git.js
+++ b/lib/git.js
@@ -33,8 +33,8 @@ function init() {
                 return core.setFailed(`The deployment folder cannot be prefixed with '/' or './'. Instead reference the folder name directly.`);
             }
             yield util_1.execute(`git init`, constants_1.workspace);
-            yield util_1.execute(`git config user.name ${constants_1.action.pusher.name}`, constants_1.workspace);
-            yield util_1.execute(`git config user.email ${constants_1.action.pusher.email}`, constants_1.workspace);
+            yield util_1.execute(`git config user.name ${constants_1.action.name}`, constants_1.workspace);
+            yield util_1.execute(`git config user.email ${constants_1.action.email}`, constants_1.workspace);
         }
         catch (error) {
             core.setFailed(`There was an error initializing the repository: ${error}`);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,7 @@ export const action = {
       ? pusher.name
       : process.env.GITHUB_ACTOR
       ? process.env.GITHUB_ACTOR
+      : "GitHub Pages Deploy Action",
   email:
     pusher && pusher.email
       ? pusher.email

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,7 +19,16 @@ export const action = {
   accessToken: core.getInput("ACCESS_TOKEN"),
   branch: core.getInput("BRANCH"),
   baseBranch: core.getInput("BASE_BRANCH") || "master",
-  pusher
+  name:
+    pusher && pusher.name
+      ? pusher.name
+      : process.env.GITHUB_ACTOR
+      ? process.env.GITHUB_ACTOR
+  email:
+    pusher && pusher.email
+      ? pusher.email
+      : `${process.env.GITHUB_ACTOR ||
+          "github-pages-deploy-action"}@users.noreply.github.com`
 };
 
 // Repository path used for commits/pushes.

--- a/src/git.ts
+++ b/src/git.ts
@@ -21,8 +21,8 @@ export async function init(): Promise<any> {
     }
 
     await execute(`git init`, workspace);
-    await execute(`git config user.name ${action.pusher.name}`, workspace);
-    await execute(`git config user.email ${action.pusher.email}`, workspace);
+    await execute(`git config user.name ${action.name}`, workspace);
+    await execute(`git config user.email ${action.email}`, workspace);
   } catch (error) {
     core.setFailed(`There was an error initializing the repository: ${error}`);
   } finally {


### PR DESCRIPTION
**Description**
> Provide a description of what your changes do.

As there's no `pusher` data in a scheduled job, the action will error due to it calling on `pusher.name` and `pusher.email`. This change adds a series of fallbacks, starting with the `GITHUB_ACTOR` env variable, followed by a generic string.

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

* The action should behave as normal, except in schedule jobs it shouldn't fail the build.
* This can be tested via `releases/v3-test`. 

**Additional Notes**
> Anything else that will help us test the pull request.

Closes issue #61. 