### PR TITLE
Automatically remove hashed files

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Below you'll find a description of what each option does.
 | `BRANCH`  | This is the branch you wish to deploy to, for example `gh-pages` or `docs`.  | `with` | **Yes** |
 | `FOLDER`  | The folder in your repository that you want to deploy. If your build script compiles into a directory named `build` you'd put it here. **Folder paths cannot have a leading `/` or `./`**. If you wish to deploy the root directory you can place a `.` here. | `with` | **Yes** |
 | `BASE_BRANCH`  | The base branch of your repository which you'd like to checkout prior to deploying. This defaults to `master`.  | `with` | **No** |
+| `CLEAN`  | If your project generates hashed files on build you can use this option to automatically delete them from the deployment branch with each deploy. This option can be toggled on by setting it to `true`.  | `with` | **No** |
 
 With the action correctly configured you should see the workflow trigger the deployment under the configured conditions.
 

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -4,17 +4,12 @@ process.env["INPUT_FOLDER"] = "build";
 import { execute } from "../src/util";
 import { init, generateBranch, deploy } from "../src/git";
 import {action} from '../src/constants'
-import {cp} from '@actions/io';
 import _ from 'lodash';
 
 const originalAction = _.cloneDeep(action);
 
 jest.mock("../src/util", () => ({
   execute: jest.fn()
-}));
-
-jest.mock("@actions/io", () => ({
-  cp: jest.fn()
 }));
 
 describe("git", () => {
@@ -136,25 +131,7 @@ describe("git", () => {
       const call = await deploy();
 
       // Includes the call to generateBranch
-      expect(execute).toBeCalledTimes(15);
-      expect(cp).toBeCalledTimes(1)
-      expect(call).toBe('Commit step complete...')
-    })
-
-    it('should execute six commands if root is used', async () => {
-      Object.assign(action, {
-        build: '.',
-        gitHubToken: '123',
-        pusher: {
-          name: 'asd',
-          email: 'as@cat'
-        }})
-  
-      const call = await deploy();
-
-      // Includes the call to generateBranch
       expect(execute).toBeCalledTimes(16);
-      expect(cp).toBeCalledTimes(0)
       expect(call).toBe('Commit step complete...')
     })
   })

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -24,6 +24,7 @@ exports.action = {
     accessToken: core.getInput("ACCESS_TOKEN"),
     branch: core.getInput("BRANCH"),
     baseBranch: core.getInput("BASE_BRANCH") || "master",
+    clean: core.getInput("CLEAN"),
     pusher
 };
 // Repository path used for commits/pushes.

--- a/lib/git.js
+++ b/lib/git.js
@@ -17,7 +17,6 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", { value: true });
 const core = __importStar(require("@actions/core"));
-const io_1 = require("@actions/io");
 const util_1 = require("./util");
 const constants_1 = require("./constants");
 /** Generates the branch if it doesn't exist on the remote.
@@ -91,17 +90,9 @@ function deploy() {
         yield util_1.execute(`git worktree add --checkout ${temporaryDeploymentDirectory} origin/${constants_1.action.branch}`, constants_1.workspace);
         /*
           Pushes all of the build files into the deployment directory.
-          Allows the user to specify the root if '.' is provided. */
-        if (constants_1.action.build === constants_1.root) {
-            // rsync is executed here so the .git and temporary deployment directories don't get duplicated.
-            yield util_1.execute(`rsync -q -av --progress ${constants_1.action.build}/. ${temporaryDeploymentDirectory} --exclude .git --exclude .github --exclude ${temporaryDeploymentDirectory}`, constants_1.workspace);
-        }
-        else {
-            yield io_1.cp(`${constants_1.action.build}/.`, temporaryDeploymentDirectory, {
-                recursive: true,
-                force: true
-            });
-        }
+          Allows the user to specify the root if '.' is provided.
+          rysync is used to prevent file duplication. */
+        yield util_1.execute(`rsync -q -av --progress ${constants_1.action.build}/. ${temporaryDeploymentDirectory} ${constants_1.action.clean && `--delete`} --exclude .git --exclude .github ${constants_1.action.build === constants_1.root && `--exclude ${temporaryDeploymentDirectory}`}`, constants_1.workspace);
         const hasFilesToCommit = yield util_1.execute(`git status --porcelain`, temporaryDeploymentDirectory);
         if (!hasFilesToCommit && !constants_1.isTest) {
             console.log("There is nothing to commit. Exiting...");

--- a/lib/git.js
+++ b/lib/git.js
@@ -92,7 +92,7 @@ function deploy() {
           Pushes all of the build files into the deployment directory.
           Allows the user to specify the root if '.' is provided.
           rysync is used to prevent file duplication. */
-        yield util_1.execute(`rsync -q -av --progress ${constants_1.action.build}/. ${temporaryDeploymentDirectory} ${constants_1.action.clean && `--delete`} --exclude .git --exclude .github ${constants_1.action.build === constants_1.root && `--exclude ${temporaryDeploymentDirectory}`}`, constants_1.workspace);
+        yield util_1.execute(`rsync -q -av --progress ${constants_1.action.build}/. ${temporaryDeploymentDirectory} ${constants_1.action.clean ? `--delete` : ""} --exclude .git --exclude .github ${constants_1.action.build === constants_1.root ? `--exclude ${temporaryDeploymentDirectory}` : ""}`, constants_1.workspace);
         const hasFilesToCommit = yield util_1.execute(`git status --porcelain`, temporaryDeploymentDirectory);
         if (!hasFilesToCommit && !constants_1.isTest) {
             console.log("There is nothing to commit. Exiting...");

--- a/lib/git.js
+++ b/lib/git.js
@@ -92,7 +92,7 @@ function deploy() {
           Pushes all of the build files into the deployment directory.
           Allows the user to specify the root if '.' is provided.
           rysync is used to prevent file duplication. */
-        yield util_1.execute(`rsync -q -av --progress ${constants_1.action.build}/. ${temporaryDeploymentDirectory} ${constants_1.action.clean ? `--delete` : ""} --exclude .git --exclude .github ${constants_1.action.build === constants_1.root ? `--exclude ${temporaryDeploymentDirectory}` : ""}`, constants_1.workspace);
+        yield util_1.execute(`rsync -q -av --progress ${constants_1.action.build}/. ${temporaryDeploymentDirectory} ${constants_1.action.clean ? `--delete --exclude CNAME --exclude .nojekyll` : ""}  --exclude .git --exclude .github ${constants_1.action.build === constants_1.root ? `--exclude ${temporaryDeploymentDirectory}` : ""}`, constants_1.workspace);
         const hasFilesToCommit = yield util_1.execute(`git status --porcelain`, temporaryDeploymentDirectory);
         if (!hasFilesToCommit && !constants_1.isTest) {
             console.log("There is nothing to commit. Exiting...");

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
   "dependencies": {
     "@actions/core": "^1.0.0",
     "@actions/exec": "^1.0.1",
-    "@actions/github": "^1.1.0",
-    "@actions/io": "^1.0.1"
+    "@actions/github": "^1.1.0"
   },
   "devDependencies": {
     "@types/jest": "^24.0.23",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -19,6 +19,7 @@ export const action = {
   accessToken: core.getInput("ACCESS_TOKEN"),
   branch: core.getInput("BRANCH"),
   baseBranch: core.getInput("BASE_BRANCH") || "master",
+  clean: core.getInput("CLEAN"),
   pusher
 };
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -85,19 +85,12 @@ export async function deploy(): Promise<any> {
 
   /*
     Pushes all of the build files into the deployment directory.
-    Allows the user to specify the root if '.' is provided. */
-  if (action.build === root) {
-    // rsync is executed here so the .git and temporary deployment directories don't get duplicated.
+    Allows the user to specify the root if '.' is provided.
+    rysync is used to prevent file duplication. */
     await execute(
-      `rsync -q -av --progress ${action.build}/. ${temporaryDeploymentDirectory} --exclude .git --exclude .github --exclude ${temporaryDeploymentDirectory}`,
+      `rsync -q -av --progress ${action.build}/. ${temporaryDeploymentDirectory} ${action.clean && `--delete`} --exclude .git --exclude .github ${action.build === root && `--exclude ${temporaryDeploymentDirectory}`}`,
       workspace
     );
-  } else {
-    await cp(`${action.build}/.`, temporaryDeploymentDirectory, {
-      recursive: true,
-      force: true
-    });
-  }
 
   const hasFilesToCommit = await execute(
     `git status --porcelain`,

--- a/src/git.ts
+++ b/src/git.ts
@@ -87,10 +87,16 @@ export async function deploy(): Promise<any> {
     Pushes all of the build files into the deployment directory.
     Allows the user to specify the root if '.' is provided.
     rysync is used to prevent file duplication. */
-    await execute(
-      `rsync -q -av --progress ${action.build}/. ${temporaryDeploymentDirectory} ${action.clean && `--delete`} --exclude .git --exclude .github ${action.build === root && `--exclude ${temporaryDeploymentDirectory}`}`,
-      workspace
-    );
+  await execute(
+    `rsync -q -av --progress ${
+      action.build
+    }/. ${temporaryDeploymentDirectory} ${
+      action.clean ? `--delete` : ""
+    } --exclude .git --exclude .github ${
+      action.build === root ? `--exclude ${temporaryDeploymentDirectory}` : ""
+    }`,
+    workspace
+  );
 
   const hasFilesToCommit = await execute(
     `git status --porcelain`,

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,5 +1,4 @@
 import * as core from "@actions/core";
-import { cp } from "@actions/io";
 import { execute } from "./util";
 import { workspace, action, root, repositoryPath, isTest } from "./constants";
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -91,8 +91,8 @@ export async function deploy(): Promise<any> {
     `rsync -q -av --progress ${
       action.build
     }/. ${temporaryDeploymentDirectory} ${
-      action.clean ? `--delete` : ""
-    } --exclude .git --exclude .github ${
+      action.clean ? `--delete --exclude CNAME --exclude .nojekyll` : ""
+    }  --exclude .git --exclude .github ${
       action.build === root ? `--exclude ${temporaryDeploymentDirectory}` : ""
     }`,
     workspace

--- a/yarn.lock
+++ b/yarn.lock
@@ -17,10 +17,6 @@
     "@octokit/graphql" "^2.0.1"
     "@octokit/rest" "^16.15.0"
 
-"@actions/io@^1.0.1":
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/@actions/io/-/io-1.0.1.tgz#81a9418fe2bbdef2d2717a8e9f85188b9c565aca"
-
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"


### PR DESCRIPTION
**Description**
> Provide a description of what your changes do.

Creates a `CLEAN` action variable that forces the action to remove hashed files from the deployment branch. Utilizes `rsync --delete` and ignores `CNAME` and `.nojekyll` files so they don't get deleted if this option is toggled.

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

* This can be used in `releases/v3-test`.

**Additional Notes**
> Anything else that will help us test the pull request.

Closes issue #60.