### PR TITLE
Fix SSH example on README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ jobs:
           npm run-script build
           
       - name: Install SSH Client
-      - uses: webfactory/ssh-agent@v0.2.0 # This step installs the ssh client into the workflow run. There's many options available for this on the action marketplace.
+        uses: webfactory/ssh-agent@v0.2.0 # This step installs the ssh client into the workflow run. There's many options available for this on the action marketplace.
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 


### PR DESCRIPTION
**Description**
> Provide a description of what your changes do.

Fix a syntax error with an extra '-' on the full SSH example on README.md, found this while trying to use the example. No changes for build.

Using the example lead to this error: -

 ```
Invalid Workflow File
every step must define a `uses` or `run` key
```
**Testing Instructions**
> Give us step by step instructions on how to test your changes.

 Just follow along the SSH example with github actions, it should no longer say `Invalid Workflow File`