### PR TITLE
Add configuration for alternate deployment repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ In addition to the deployment options you must also configure the following.
 | ------------- | ------------- | ------------- | ------------- |
 | `GIT_CONFIG_NAME`  | Allows you to customize the name that is attached to the GitHub config which is used when pushing the deployment commits. If this is not included it will use the name in the GitHub context, followed by the name of the action.  | `with` | **No** |
 | `GIT_CONFIG_EMAIL`  | Allows you to customize the email that is attached to the GitHub config which is used when pushing the deployment commits. If this is not included it will use the email in the GitHub context, followed by a generic noreply GitHub email.  | `with` | **No** |
+| `REMOTE_REPOSITORY`  | If you'd like to push to an alternate repository, specify the `organization/repository` path.  | `with` | **No** |
 | `TARGET_FOLDER`  | If you'd like to push the contents of the deployment folder into a specific directory on the deployment branch you can specify it here.  | `with` | **No** |
 | `BASE_BRANCH`  | The base branch of your repository which you'd like to checkout prior to deploying. This defaults to the current commit [SHA](http://en.wikipedia.org/wiki/SHA-1) that triggered the build followed by `master` if it doesn't exist. This is useful for making deployments from another branch, and also may be necessary when using a scheduled job.  | `with` | **No** |
 | `COMMIT_MESSAGE`  | If you need to customize the commit message for an integration you can do so.  | `with` | **No** |

--- a/action.yml
+++ b/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: 'The base branch of your repository which you would like to checkout prior to deploying. This defaults to the current commit SHA that triggered the build followed by master if it does not exist. This is useful for making deployments from another branch, and also may be necessary when using a scheduled job.'
     required: false
 
+  REMOTE_REPOSITORY:
+    description: If you'd like to push to an alternate repository, specify the `organization/repository` path.
+    required: false
+
   COMMIT_MESSAGE:
     description: 'If you need to customize the commit message for an integration you can do so.'
     required: false

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -32,9 +32,11 @@ exports.action = {
             ? pusher.email
             : `${process.env.GITHUB_ACTOR ||
                 "github-pages-deploy-action"}@users.noreply.github.com`,
-    gitHubRepository: repository && repository.full_name
-        ? repository.full_name
-        : process.env.GITHUB_REPOSITORY,
+    gitHubRepository: !util_1.isNullOrUndefined(core_1.getInput("REMOTE_REPOSITORY"))
+        ? core_1.getInput("REMOTE_REPOSITORY")
+        : repository && repository.full_name
+            ? repository.full_name
+            : process.env.GITHUB_REPOSITORY,
     gitHubToken: core_1.getInput("GITHUB_TOKEN"),
     name: !util_1.isNullOrUndefined(core_1.getInput("GIT_CONFIG_NAME"))
         ? core_1.getInput("GIT_CONFIG_NAME")

--- a/lib/git.js
+++ b/lib/git.js
@@ -33,9 +33,8 @@ function init() {
             yield execute_1.execute(`git init`, constants_1.workspace);
             yield execute_1.execute(`git config user.name ${constants_1.action.name}`, constants_1.workspace);
             yield execute_1.execute(`git config user.email ${constants_1.action.email}`, constants_1.workspace);
-            yield execute_1.execute(`git remote rm origin`, constants_1.workspace);
-            yield execute_1.execute(`git remote add origin ${constants_1.repositoryPath}`, constants_1.workspace);
-            yield execute_1.execute(`git fetch`, constants_1.workspace);
+            yield execute_1.execute(`git remote add deployment-repo ${constants_1.repositoryPath}`, constants_1.workspace);
+            yield execute_1.execute(`git fetch deployment-repo`, constants_1.workspace);
         }
         catch (error) {
             console.log(`There was an error initializing the repository: ${error}`);
@@ -70,7 +69,7 @@ function generateBranch() {
             yield execute_1.execute(`git checkout --orphan ${constants_1.action.branch}`, constants_1.workspace);
             yield execute_1.execute(`git reset --hard`, constants_1.workspace);
             yield execute_1.execute(`git commit --allow-empty -m "Initial ${constants_1.action.branch} commit."`, constants_1.workspace);
-            yield execute_1.execute(`git push ${constants_1.repositoryPath} ${constants_1.action.branch}`, constants_1.workspace);
+            yield execute_1.execute(`git push deployment-repo ${constants_1.action.branch}`, constants_1.workspace);
             yield execute_1.execute(`git fetch`, constants_1.workspace);
         }
         catch (error) {
@@ -93,15 +92,15 @@ function deploy() {
             Checks to see if the remote exists prior to deploying.
             If the branch doesn't exist it gets created here as an orphan.
           */
-        const branchExists = yield execute_1.execute(`git ls-remote --heads ${constants_1.repositoryPath} ${constants_1.action.branch} | wc -l`, constants_1.workspace);
+        const branchExists = yield execute_1.execute(`git ls-remote --heads deployment-repo ${constants_1.action.branch} | wc -l`, constants_1.workspace);
         if (!branchExists && !constants_1.action.isTest) {
             console.log("Deployment branch does not exist. Creating....");
             yield generateBranch();
         }
         // Checks out the base branch to begin the deployment process.
         yield switchToBaseBranch();
-        yield execute_1.execute(`git fetch ${constants_1.repositoryPath}`, constants_1.workspace);
-        yield execute_1.execute(`git worktree add --checkout ${temporaryDeploymentDirectory} origin/${constants_1.action.branch}`, constants_1.workspace);
+        yield execute_1.execute(`git fetch deployment-repo`, constants_1.workspace);
+        yield execute_1.execute(`git worktree add --checkout ${temporaryDeploymentDirectory} deployment-repo/${constants_1.action.branch}`, constants_1.workspace);
         // Ensures that items that need to be excluded from the clean job get parsed.
         let excludes = "";
         if (constants_1.action.clean && constants_1.action.cleanExclude) {
@@ -133,7 +132,7 @@ function deploy() {
         yield execute_1.execute(`git commit -m "${!util_1.isNullOrUndefined(constants_1.action.commitMessage)
             ? constants_1.action.commitMessage
             : `Deploying to ${constants_1.action.branch} from ${constants_1.action.baseBranch}`} - ${process.env.GITHUB_SHA} 🚀" --quiet`, temporaryDeploymentDirectory);
-        yield execute_1.execute(`git push --force ${constants_1.repositoryPath} ${temporaryDeploymentBranch}:${constants_1.action.branch}`, temporaryDeploymentDirectory);
+        yield execute_1.execute(`git push --force deployment-repo ${temporaryDeploymentBranch}:${constants_1.action.branch}`, temporaryDeploymentDirectory);
         // Cleans up temporary files/folders and restores the git state.
         console.log("Running post deployment cleanup jobs... 🔧");
         yield execute_1.execute(`rm -rf ${temporaryDeploymentDirectory}`, constants_1.workspace);

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -26,10 +26,11 @@ export const action = {
     ? pusher.email
     : `${process.env.GITHUB_ACTOR ||
         "github-pages-deploy-action"}@users.noreply.github.com`,
-  gitHubRepository:
-    repository && repository.full_name
-      ? repository.full_name
-      : process.env.GITHUB_REPOSITORY,
+  gitHubRepository: !isNullOrUndefined(getInput("REMOTE_REPOSITORY"))
+    ? getInput("REMOTE_REPOSITORY")
+    : repository && repository.full_name
+    ? repository.full_name
+    : process.env.GITHUB_REPOSITORY,
   gitHubToken: getInput("GITHUB_TOKEN"),
   name: !isNullOrUndefined(getInput("GIT_CONFIG_NAME"))
     ? getInput("GIT_CONFIG_NAME")

--- a/src/git.ts
+++ b/src/git.ts
@@ -42,9 +42,8 @@ export async function init(): Promise<void> {
     await execute(`git init`, workspace);
     await execute(`git config user.name ${action.name}`, workspace);
     await execute(`git config user.email ${action.email}`, workspace);
-    await execute(`git remote rm origin`, workspace);
-    await execute(`git remote add origin ${repositoryPath}`, workspace);
-    await execute(`git fetch`, workspace);
+    await execute(`git remote add deployment-repo ${repositoryPath}`, workspace);
+    await execute(`git fetch deployment-repo`, workspace);
   } catch (error) {
     console.log(`There was an error initializing the repository: ${error}`);
   } finally {
@@ -83,7 +82,7 @@ export async function generateBranch(): Promise<void> {
       `git commit --allow-empty -m "Initial ${action.branch} commit."`,
       workspace
     );
-    await execute(`git push ${repositoryPath} ${action.branch}`, workspace);
+    await execute(`git push deployment-repo ${action.branch}`, workspace);
     await execute(`git fetch`, workspace);
   } catch (error) {
     setFailed(`There was an error creating the deployment branch: ${error} ❌`);
@@ -103,7 +102,7 @@ export async function deploy(): Promise<string> {
       If the branch doesn't exist it gets created here as an orphan.
     */
   const branchExists = await execute(
-    `git ls-remote --heads ${repositoryPath} ${action.branch} | wc -l`,
+    `git ls-remote --heads deployment-repo ${action.branch} | wc -l`,
     workspace
   );
   if (!branchExists && !action.isTest) {
@@ -113,9 +112,9 @@ export async function deploy(): Promise<string> {
 
   // Checks out the base branch to begin the deployment process.
   await switchToBaseBranch();
-  await execute(`git fetch ${repositoryPath}`, workspace);
+  await execute(`git fetch deployment-repo`, workspace);
   await execute(
-    `git worktree add --checkout ${temporaryDeploymentDirectory} origin/${action.branch}`,
+    `git worktree add --checkout ${temporaryDeploymentDirectory} deployment-repo/${action.branch}`,
     workspace
   );
 
@@ -178,7 +177,7 @@ export async function deploy(): Promise<string> {
     temporaryDeploymentDirectory
   );
   await execute(
-    `git push --force ${repositoryPath} ${temporaryDeploymentBranch}:${action.branch}`,
+    `git push --force deployment-repo ${temporaryDeploymentBranch}:${action.branch}`,
     temporaryDeploymentDirectory
   );
 


### PR DESCRIPTION
**Description**
Allow configuring a deployment to a different repository. Also explicitly declared a separate remote instance since I believe it makes the code flow clearer, and avoids weird conflicts I encountered in testing if there exists branch naming collisions between the "former" origin and a new secondary one.

**Testing Instructions**
I've tested these changes deploying from private/public repos to self with GITHUB_TOKEN and remote repositories using ACCESS_TOKEN.

**Additional Notes**
Reasoning for wanting these changes: Github repositories must be made public in order to enable the associated github pages. There are instances where I'd like to publish github documentation from a private repository without having to expose all of its files and history.

related to #21 