### PR TITLE
Update readme examples to reflect the removal of build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://github.com/JamesIves/github-pages-deploy-action/workflows/unit-tests/badge.svg)](https://github.com/JamesIves/github-pages-deploy-action/actions) [![Actions Status](https://github.com/JamesIves/github-pages-deploy-action/workflows/integration-tests/badge.svg)](https://github.com/JamesIves/github-pages-deploy-action/actions) [![View Action](https://img.shields.io/badge/action-marketplace-blue.svg?logo=github&color=orange)](https://github.com/marketplace/actions/deploy-to-github-pages) [![Version](https://img.shields.io/github/v/release/JamesIves/github-pages-deploy-action.svg?logo=github)](https://github.com/JamesIves/github-pages-deploy-action/releases) [![Codecov Coverage](https://codecov.io/gh/JamesIves/github-pages-deploy-action/branch/dev/graph/badge.svg)](https://codecov.io/gh/JamesIves/github-pages-deploy-action/branch/dev)
 
-This [GitHub action](https://github.com/features/actions) will handle the deploy process of your project to [GitHub Pages](https://pages.github.com/). It can be configured to upload your production-ready code into any branch you'd like, including `gh-pages` and `docs`.
+This [GitHub Action](https://github.com/features/actions) will deploy your project to [GitHub Pages](https://pages.github.com/). It can be configured to upload your production-ready code into any branch you'd like, including `gh-pages` and `docs`.
 
 ![Example Screenshot](screenshot.png)
 
@@ -24,7 +24,12 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Build and Deploy 🚀
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
@@ -134,7 +139,7 @@ With this configured you must add the `ssh-agent` step to your workflow and set 
   with:
     ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
-- name: Build and Deploy 🚀
+- name: Deploy 🚀
   uses: JamesIves/github-pages-deploy-action@releases/v3
   with:
     SSH: true
@@ -160,17 +165,17 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install 🔧
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
           npm install
-          npm run-script build
+          npm run build
 
       - name: Install SSH Client 🔑
         uses: webfactory/ssh-agent@v0.2.0 # This step installs the ssh client into the workflow run. There's many options available for this on the action marketplace.
         with:
           ssh-private-key: ${{ secrets.DEPLOY_KEY }}
 
-      - name: Build and Deploy Repo 🚀
+      - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3-test
         with:
           BASE_BRANCH: master
@@ -212,10 +217,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install 🔧 # The project is built using npm and placed in the 'build' folder.
+      - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
           npm install
-          npm run-script build
+          npm run build
 
       - name: Upload Artifacts 🔺 # The project is then uploaded as an artifact named 'site'.
         uses: actions/upload-artifact@v1
@@ -237,7 +242,7 @@ jobs:
         with:
           name: site
 
-      - name: Build and Deploy 🚀
+      - name: Deploy 🚀
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}


### PR DESCRIPTION
Hi there! I've just made a few small changes to the docs to reflect the fact that v3 no longer supports running build scripts, and any building-related steps must be done before this action.

I stuck with the `npm install` and `npm run build` example that was already there and expanded on the comments to make sure readers know to replace this step with their own build commands, or remove it entirely.

Let me know if any wording needs tweaking. Thanks! 😊