### PR TITLE
append commit SHA to commit msg, only if not a part of it already.

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -102,7 +102,9 @@ export async function deploy(action: ActionInterface): Promise<void> {
 
     const commitMessage = !isNullOrUndefined(action.commitMessage)
       ? (action.commitMessage as string)
-      : `Deploying to ${action.branch} from ${action.baseBranch} ${process.env.GITHUB_SHA ? `@ ${process.env.GITHUB_SHA}` : ''} 🚀`
+      : `Deploying to ${action.branch} from ${action.baseBranch} ${
+          process.env.GITHUB_SHA ? `@ ${process.env.GITHUB_SHA}` : ''
+        } 🚀`
 
     /*
         Checks to see if the remote exists prior to deploying.

--- a/src/git.ts
+++ b/src/git.ts
@@ -102,7 +102,7 @@ export async function deploy(action: ActionInterface): Promise<void> {
 
     const commitMessage = !isNullOrUndefined(action.commitMessage)
       ? (action.commitMessage as string)
-      : `Deploying to ${action.branch} from ${action.baseBranch} @ ${process.env.GITHUB_SHA} 🚀`
+      : `Deploying to ${action.branch} from ${action.baseBranch} ${process.env.GITHUB_SHA ? `@ ${process.env.GITHUB_SHA}` : ''} 🚀`
 
     /*
         Checks to see if the remote exists prior to deploying.

--- a/src/git.ts
+++ b/src/git.ts
@@ -100,11 +100,13 @@ export async function deploy(action: ActionInterface): Promise<void> {
   try {
     hasRequiredParameters(action)
 
-    const commitMessage = `${
-      !isNullOrUndefined(action.commitMessage)
-        ? action.commitMessage
+    let commitMessage = !isNullOrUndefined(action.commitMessage)
+        ? action.commitMessage as string
         : `Deploying to ${action.branch} from ${action.baseBranch}`
-    } ${process.env.GITHUB_SHA ? `@ ${process.env.GITHUB_SHA}` : ''} 🚀`
+
+    if (process.env.GITHUB_SHA && !commitMessage.includes(process.env.GITHUB_SHA)) {
+      commitMessage += ` @ ${process.env.GITHUB_SHA} 🚀`
+    }
 
     /*
         Checks to see if the remote exists prior to deploying.

--- a/src/git.ts
+++ b/src/git.ts
@@ -100,13 +100,9 @@ export async function deploy(action: ActionInterface): Promise<void> {
   try {
     hasRequiredParameters(action)
 
-    let commitMessage = !isNullOrUndefined(action.commitMessage)
-        ? action.commitMessage as string
-        : `Deploying to ${action.branch} from ${action.baseBranch}`
-
-    if (process.env.GITHUB_SHA && !commitMessage.includes(process.env.GITHUB_SHA)) {
-      commitMessage += ` @ ${process.env.GITHUB_SHA} 🚀`
-    }
+    const commitMessage = !isNullOrUndefined(action.commitMessage)
+      ? (action.commitMessage as string)
+      : `Deploying to ${action.branch} from ${action.baseBranch} @ ${process.env.GITHUB_SHA} 🚀`
 
     /*
         Checks to see if the remote exists prior to deploying.


### PR DESCRIPTION
__*problem*__: user provided commit message being modified (appending the commit SHA).
As the user, it is a bit annoying to have the commit SHA appear twice in the commit message.

__*possible solutions:*__
* do not append the commit SHA, if user has already included it the commit message.
* let the user decide whether the user's commit message can be modified. *(maybe via argument in `action.yml`)*.