### PR TITLE
Make sure rm -rf actually works.

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -239,6 +239,7 @@ export async function deploy(action: ActionInterface): Promise<void> {
     )
   } finally {
     // Ensures the deployment directory is safely removed.
+    await execute(`chmod u+w -R ${temporaryDeploymentDirectory}`, action.workspace)
     await execute(`rm -rf ${temporaryDeploymentDirectory}`, action.workspace)
   }
 }

--- a/src/git.ts
+++ b/src/git.ts
@@ -239,7 +239,10 @@ export async function deploy(action: ActionInterface): Promise<void> {
     )
   } finally {
     // Ensures the deployment directory is safely removed.
-    await execute(`chmod u+w -R ${temporaryDeploymentDirectory}`, action.workspace)
+    await execute(
+      `chmod u+w -R ${temporaryDeploymentDirectory}`,
+      action.workspace
+    )
     await execute(`rm -rf ${temporaryDeploymentDirectory}`, action.workspace)
   }
 }


### PR DESCRIPTION
This makes sure directories in `temporaryDeploymentDirectory` are writabe before attempting to remove them. Fixes: #241