### PR TITLE
Fixed 2 typos in entrypoint.sh

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -45,7 +45,7 @@ then
   COMMIT_NAME="${GITHUB_ACTOR:-GitHub Pages Deploy Action}"
 fi
 
-# Directs the action to the the Github workspace.
+# Directs the action to the the GitHub workspace.
 cd $GITHUB_WORKSPACE && \
 
 # Configures Git.
@@ -78,7 +78,7 @@ echo "Running build scripts... $BUILD_SCRIPT" && \
 eval "$BUILD_SCRIPT" && \
 
 if [ "$CNAME" ]; then
-  echo "Generating a CNAME file in in the $FOLDER directory..."
+  echo "Generating a CNAME file in the $FOLDER directory..."
   echo $CNAME > $FOLDER/CNAME
 fi
 


### PR DESCRIPTION
**Description**

There were two typos in the `entrypoint.sh` file on the `master` branch. One in the comments (`Github` > `GitHub`) and one in the log messages when creating a `CNAME` file, there was an extra `in` word (`in in`> `in`).

```diff
- # Directs the action to the the Github workspace.
+ # Directs the action to the the GitHub workspace.

- echo "Generating a CNAME file in in the $FOLDER directory..."
+ echo "Generating a CNAME file in the $FOLDER directory..."
```
