### PR TITLE
supress secret from logs if it appears multiple times

### DIFF
--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -148,9 +148,9 @@ describe('util', () => {
           silent: false
         }
 
-        const string = `This is an error message! It contains ${action.accessToken} and ${action.gitHubToken} and ${action.repositoryPath}`
+        const string = `This is an error message! It contains ${action.accessToken} and ${action.gitHubToken} and ${action.repositoryPath} and ${action.accessToken} again!`
         expect(suppressSensitiveInformation(string, action)).toBe(
-          'This is an error message! It contains *** and *** and ***'
+          'This is an error message! It contains *** and *** and *** and *** again!'
         )
       })
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,9 @@
 import {isDebug} from '@actions/core'
 import {ActionInterface} from './constants'
 
+const replaceAll = (input: string, find: string, replace: string): string =>
+  input.split(find).join(replace)
+
 /* Utility function that checks to see if a value is undefined or not. */
 export const isNullOrUndefined = (value: any): boolean =>
   typeof value === 'undefined' || value === null || value === ''
@@ -64,16 +67,14 @@ export const suppressSensitiveInformation = (
     return value
   }
 
-  if (action.accessToken) {
-    value = value.replace(action.accessToken, '***')
-  }
+  const orderedByLength = ([
+    action.accessToken,
+    action.gitHubToken,
+    action.repositoryPath
+  ].filter(Boolean) as string[]).sort((a, b) => b.length - a.length)
 
-  if (action.gitHubToken) {
-    value = value.replace(action.gitHubToken, '***')
-  }
-
-  if (action.repositoryPath) {
-    value = value.replace(action.repositoryPath, '***')
+  for (const find of orderedByLength) {
+    value = replaceAll(value, find, '***')
   }
 
   return value


### PR DESCRIPTION
**Description**
You'd have thought `String.prototype.replace` would replace all instances right? Wrong! It only replaces the first one. `replaceAll` is coming soon but not everywhere yet.

This PR implements a `replaceAll`. It also orders the secrets by length descending, so that if one secret contains another secret inside it, both will get obfuscated. Disable the sort and you'll see the test fail.

**Testing Instructions**
Run the tests.