### PR TITLE
Feat: add support for absolute paths

### DIFF
--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -178,7 +178,7 @@ describe('git', () => {
       }
     })
 
-    it('should fail if the build folder begins with a /', async () => {
+    it('should not fail if the build folder begins with a /', async () => {
       Object.assign(action, {
         silent: false,
         accessToken: '123',
@@ -191,17 +191,11 @@ describe('git', () => {
         }
       })
 
-      try {
-        await init(action)
-      } catch (e) {
-        expect(execute).toBeCalledTimes(0)
-        expect(e.message).toMatch(
-          "There was an error initializing the repository: Incorrectly formatted build folder. The deployment folder cannot be prefixed with '/' or './'. Instead reference the folder name directly. ❌"
-        )
-      }
+      await init(action)
+      expect(execute).toBeCalledTimes(6)
     })
 
-    it('should fail if the build folder begins with a ./', async () => {
+    it('should not fail if the build folder begins with a ./', async () => {
       Object.assign(action, {
         silent: false,
         accessToken: '123',
@@ -213,14 +207,24 @@ describe('git', () => {
         }
       })
 
-      try {
-        await init(action)
-      } catch (e) {
-        expect(execute).toBeCalledTimes(0)
-        expect(e.message).toMatch(
-          "There was an error initializing the repository: Incorrectly formatted build folder. The deployment folder cannot be prefixed with '/' or './'. Instead reference the folder name directly. ❌"
-        )
-      }
+      await init(action)
+      expect(execute).toBeCalledTimes(6)
+    })
+
+    it('should not fail if the build folder begins with a ~', async () => {
+      Object.assign(action, {
+        silent: false,
+        accessToken: '123',
+        branch: 'branch',
+        folder: '~/assets',
+        pusher: {
+          name: 'asd',
+          email: 'as@cat'
+        }
+      })
+
+      await init(action)
+      expect(execute).toBeCalledTimes(6)
     })
 
     it('should not fail if root is used', async () => {

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -178,55 +178,6 @@ describe('git', () => {
       }
     })
 
-    it('should not fail if the build folder begins with a /', async () => {
-      Object.assign(action, {
-        silent: false,
-        accessToken: '123',
-        repositoryPath: 'JamesIves/github-pages-deploy-action',
-        branch: 'branch',
-        folder: '/',
-        pusher: {
-          name: 'asd',
-          email: 'as@cat'
-        }
-      })
-
-      await init(action)
-      expect(execute).toBeCalledTimes(6)
-    })
-
-    it('should not fail if the build folder begins with a ./', async () => {
-      Object.assign(action, {
-        silent: false,
-        accessToken: '123',
-        branch: 'branch',
-        folder: './',
-        pusher: {
-          name: 'asd',
-          email: 'as@cat'
-        }
-      })
-
-      await init(action)
-      expect(execute).toBeCalledTimes(6)
-    })
-
-    it('should not fail if the build folder begins with a ~', async () => {
-      Object.assign(action, {
-        silent: false,
-        accessToken: '123',
-        branch: 'branch',
-        folder: '~/assets',
-        pusher: {
-          name: 'asd',
-          email: 'as@cat'
-        }
-      })
-
-      await init(action)
-      expect(execute).toBeCalledTimes(6)
-    })
-
     it('should not fail if root is used', async () => {
       Object.assign(action, {
         silent: false,

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -2,6 +2,7 @@ import {
   isNullOrUndefined,
   generateTokenType,
   generateRepositoryPath,
+  generateFolderPath,
   suppressSensitiveInformation
 } from '../src/util'
 
@@ -175,6 +176,65 @@ describe('util', () => {
           'This is an error message! It contains supersecret999%%% and anothersecret123333 and https://x-access-token:supersecret999%%%@github.com/anothersecret123333'
         )
       })
+    })
+  })
+
+  describe('generateFolderPath', () => {
+    it('should return absolute path if folder name is provided', () => {
+      const action = {
+        branch: '123',
+        root: '.',
+        workspace: 'src/',
+        folder: 'build',
+        gitHubToken: null,
+        accessToken: null,
+        ssh: null,
+        silent: false
+      }
+      expect(generateFolderPath(action)).toEqual('src/build')
+    })
+
+    it('should return original path if folder name begins with /', () => {
+      const action = {
+        branch: '123',
+        root: '.',
+        workspace: 'src/',
+        folder: '/home/user/repo/build',
+        gitHubToken: null,
+        accessToken: null,
+        ssh: null,
+        silent: false
+      }
+      expect(generateFolderPath(action)).toEqual('/home/user/repo/build')
+    })
+
+    it('should process as relative path if folder name begins with ./', () => {
+      const action = {
+        branch: '123',
+        root: '.',
+        workspace: 'src/',
+        folder: './build',
+        gitHubToken: null,
+        accessToken: null,
+        ssh: null,
+        silent: false
+      }
+      expect(generateFolderPath(action)).toEqual('src/build')
+    })
+
+    it('should return absolute path if folder name begins with ~', () => {
+      const action = {
+        branch: '123',
+        root: '.',
+        workspace: 'src/',
+        folder: '~/repo/build',
+        gitHubToken: null,
+        accessToken: null,
+        ssh: null,
+        silent: false
+      }
+      process.env.HOME = '/home/user'
+      expect(generateFolderPath(action)).toEqual('/home/user/repo/build')
     })
   })
 })

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -191,7 +191,7 @@ describe('util', () => {
         ssh: null,
         silent: false
       }
-      expect(generateFolderPath(action)).toEqual('src/build')
+      expect(generateFolderPath(action, 'folder')).toEqual('src/build')
     })
 
     it('should return original path if folder name begins with /', () => {
@@ -205,7 +205,9 @@ describe('util', () => {
         ssh: null,
         silent: false
       }
-      expect(generateFolderPath(action)).toEqual('/home/user/repo/build')
+      expect(generateFolderPath(action, 'folder')).toEqual(
+        '/home/user/repo/build'
+      )
     })
 
     it('should process as relative path if folder name begins with ./', () => {
@@ -219,7 +221,7 @@ describe('util', () => {
         ssh: null,
         silent: false
       }
-      expect(generateFolderPath(action)).toEqual('src/build')
+      expect(generateFolderPath(action, 'folder')).toEqual('src/build')
     })
 
     it('should return absolute path if folder name begins with ~', () => {
@@ -234,7 +236,9 @@ describe('util', () => {
         silent: false
       }
       process.env.HOME = '/home/user'
-      expect(generateFolderPath(action)).toEqual('/home/user/repo/build')
+      expect(generateFolderPath(action, 'folder')).toEqual(
+        '/home/user/repo/build'
+      )
     })
   })
 })

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,7 +39,7 @@ export interface ActionInterface {
   /** The fully qualified repositpory path, this gets auto generated if repositoryName is provided. */
   repositoryPath?: string
   /** The root directory where your project lives. */
-  root?: string
+  root: string
   /** Wipes the commit history from the deployment branch in favor of a single commit. */
   singleCommit?: boolean | null
   /** Determines if the action should run in silent mode or not. */
@@ -108,6 +108,10 @@ export const action: ActionInterface = {
   targetFolder: getInput('TARGET_FOLDER'),
   workspace: process.env.GITHUB_WORKSPACE || ''
 }
+
+export type ActionFolders = NonNullable<
+  Pick<ActionInterface, 'folder' | 'root'>
+>
 
 /** Status codes for the action. */
 export enum Status {

--- a/src/git.ts
+++ b/src/git.ts
@@ -4,6 +4,7 @@ import fs from 'fs'
 import {ActionInterface, Status} from './constants'
 import {execute} from './execute'
 import {
+  generateFolderPath,
   hasRequiredParameters,
   isNullOrUndefined,
   suppressSensitiveInformation
@@ -228,23 +229,24 @@ export async function deploy(action: ActionInterface): Promise<Status> {
       Pushes all of the build files into the deployment directory.
       Allows the user to specify the root if '.' is provided.
       rsync is used to prevent file duplication. */
+    const folderPath = generateFolderPath(action)
     await execute(
-      `rsync -q -av --checksum --progress ${action.folder}/. ${
+      `rsync -q -av --checksum --progress ${folderPath}/. ${
         action.targetFolder
           ? `${temporaryDeploymentDirectory}/${action.targetFolder}`
           : temporaryDeploymentDirectory
       } ${
         action.clean
           ? `--delete ${excludes} ${
-              !fs.existsSync(`${action.folder}/CNAME`) ? '--exclude CNAME' : ''
+              !fs.existsSync(`${folderPath}/CNAME`) ? '--exclude CNAME' : ''
             } ${
-              !fs.existsSync(`${action.folder}/.nojekyll`)
+              !fs.existsSync(`${folderPath}/.nojekyll`)
                 ? '--exclude .nojekyll'
                 : ''
             }`
           : ''
       }  --exclude .ssh --exclude .git --exclude .github ${
-        action.folder === action.root
+        folderPath === action.root
           ? `--exclude ${temporaryDeploymentDirectory}`
           : ''
       }`,

--- a/src/git.ts
+++ b/src/git.ts
@@ -131,6 +131,8 @@ export async function generateBranch(action: ActionInterface): Promise<void> {
 
 /* Runs the necessary steps to make the deployment. */
 export async function deploy(action: ActionInterface): Promise<Status> {
+  const folderPath = generateFolderPath(action, 'folder')
+  const rootPath = generateFolderPath(action, 'root')
   const temporaryDeploymentDirectory =
     'github-pages-deploy-action-temp-deployment-folder'
   const temporaryDeploymentBranch = `github-pages-deploy-action/${Math.random()
@@ -229,7 +231,6 @@ export async function deploy(action: ActionInterface): Promise<Status> {
       Pushes all of the build files into the deployment directory.
       Allows the user to specify the root if '.' is provided.
       rsync is used to prevent file duplication. */
-    const folderPath = generateFolderPath(action)
     await execute(
       `rsync -q -av --checksum --progress ${folderPath}/. ${
         action.targetFolder
@@ -246,7 +247,7 @@ export async function deploy(action: ActionInterface): Promise<Status> {
             }`
           : ''
       }  --exclude .ssh --exclude .git --exclude .github ${
-        folderPath === action.root
+        folderPath === rootPath
           ? `--exclude ${temporaryDeploymentDirectory}`
           : ''
       }`,

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -1,6 +1,6 @@
 import {exportVariable, info, setFailed} from '@actions/core'
 import {action, ActionInterface, Status} from './constants'
-import {deploy, generateBranch, init} from './git'
+import {deploy, init} from './git'
 import {generateRepositoryPath, generateTokenType} from './util'
 
 /** Initializes and runs the action.
@@ -53,5 +53,3 @@ export default async function run(
     exportVariable('DEPLOYMENT_STATUS', status)
   }
 }
-
-export {init, deploy, generateBranch, ActionInterface}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
 import path from 'path'
 import {isDebug} from '@actions/core'
-import {ActionInterface} from './constants'
+import {ActionInterface, ActionFolders} from './constants'
 
 const replaceAll = (input: string, find: string, replace: string): string =>
   input.split(find).join(replace)
@@ -28,8 +28,11 @@ export const generateRepositoryPath = (action: ActionInterface): string =>
       }@github.com/${action.repositoryName}.git`
 
 /* Genetate absolute folder path by the provided folder name */
-export const generateFolderPath = (action: ActionInterface): string => {
-  const folderName = action.folder
+export const generateFolderPath = <K extends keyof ActionFolders>(
+  action: ActionInterface,
+  key: K
+): string => {
+  const folderName = action[key]
   const folderPath = path.isAbsolute(folderName)
     ? folderName
     : folderName.startsWith('~')

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,4 @@
+import path from 'path'
 import {isDebug} from '@actions/core'
 import {ActionInterface} from './constants'
 
@@ -26,6 +27,17 @@ export const generateRepositoryPath = (action: ActionInterface): string =>
         action.accessToken || `x-access-token:${action.gitHubToken}`
       }@github.com/${action.repositoryName}.git`
 
+/* Genetate absolute folder path by the provided folder name */
+export const generateFolderPath = (action: ActionInterface): string => {
+  const folderName = action.folder
+  const folderPath = path.isAbsolute(folderName)
+    ? folderName
+    : folderName.startsWith('~')
+    ? folderName.replace('~', process.env.HOME as string)
+    : path.join(action.workspace, folderName)
+  return folderPath
+}
+
 /* Checks for the required tokens and formatting. Throws an error if any case is matched. */
 export const hasRequiredParameters = (action: ActionInterface): void => {
   if (
@@ -46,12 +58,6 @@ export const hasRequiredParameters = (action: ActionInterface): void => {
 
   if (!action.folder || isNullOrUndefined(action.folder)) {
     throw new Error('You must provide the action with a folder to deploy.')
-  }
-
-  if (action.folder.startsWith('/') || action.folder.startsWith('./')) {
-    throw new Error(
-      "Incorrectly formatted build folder. The deployment folder cannot be prefixed with '/' or './'. Instead reference the folder name directly."
-    )
   }
 }
 


### PR DESCRIPTION
Resolves #387

**Description**
> Provide a description of what your changes do.

Add a util function to return an absolute path of `action.folder`.

Add related tests for the function.

**Testing Instructions**
> Give us step by step instructions on how to test your changes.

`yarn test`

Integration tests passed on my fork https://github.com/exuanbo/github-pages-deploy-action/commit/9161a5b4c6a49e7463380d18f4cdd47b35228ff0