### PR TITLE
Set up eslint for test files.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
   "parserOptions": {
     "ecmaVersion": 9,
     "sourceType": "module",
-    "project": "./tsconfig.json"
+    "project": "./tsconfig.lint.json"
   },
   "globals": {
     "fetch": true

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/first */
 // Initial env variable setup for tests.
 process.env['INPUT_FOLDER'] = 'build'
 process.env['GITHUB_SHA'] = '123'
@@ -23,6 +24,7 @@ jest.mock('@actions/io', () => ({
 }))
 
 jest.mock('../src/execute', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
   execute: jest.fn()
 }))

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable import/first */
 // Initial env variable setup for tests.
 process.env['INPUT_FOLDER'] = 'build'
 process.env['GITHUB_SHA'] = '123'

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "build": "rimraf lib && tsc --declaration",
     "test": "jest",
-    "lint": "eslint src/**/*.ts",
+    "lint": "eslint src/**/*.ts __tests__/**/*.ts",
     "format": "prettier --write './**/*.ts'"
   },
   "repository": {

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,7 @@
+{
+    "extends": "./tsconfig.json",
+    "compilerOptions": {
+        "rootDir": "."
+    },
+    "exclude": ["node_modules"]
+}


### PR DESCRIPTION
**Description**
I noticed the eslint plugin in VS Code to be unhappy about the test files, so I figured I might be able to fix this.

**Testing Instructions**

Run `yarn lint`, and open test files in vs code.

**Additional Notes**

Not sure which target branch to use for this ;-)