### PR TITLE
Adjust codeql action to latest recommendations

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,15 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [dev, master, releases/v2, releases/v3]
+    branches:
+      - dev
+      - 'dev-v*'
+      - 'releases/v*'
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [dev]
+    branches:
+      - dev
+      - 'dev-v*'
   schedule:
     - cron: '0 9 * * 4'
 
@@ -17,15 +22,6 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
-
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Also, add the dev and release branches, and drop master.

**Description**

There's some warnings on https://github.com/JamesIves/github-pages-deploy-action/actions/runs/415137521, which  I hope to have fixed here. Also, we use more branches now, and not master anymore.
