### PR TITLE
Use multi-line string for clean-exclude patterns.

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ By default the action does not need any token configuration and uses the provide
 | `target_folder`    | If you'd like to push the contents of the deployment folder into a specific directory on the deployment branch you can specify it here.                                                                                                                                                                                                               | `with` | **No**   |
 | `commit_message`   | If you need to customize the commit message for an integration you can do so.                                                                                                                                                                                                                                                                         | `with` | **No**   |
 | `clean`            | If your project generates hashed files on build you can use this option to automatically delete them from the deployment branch with each deploy. This option is turned on by default, and can be toggled off by setting it to `false`.                                                                                                                                              | `with` | **No**   |
-| `clean_exclude`    | If you need to use `clean` but you'd like to preserve certain files or folders you can use this option. This should be formatted as an array but stored as a string. For example: `'["filename.js", "folder"]'`                                                                                                                                       | `with` | **No**   |
+| `clean-exclude`    | If you need to use `clean` but you'd like to preserve certain files or folders you can use this option. This should contain each pattern as a single line in a multiline string.                                                                                                                                       | `with` | **No**   |
 | `dry_run`          | Do not actually push back, but use `--dry-run` on `git push` invocations insead.                                                                                                               | `with` | **No**   |
 | `single_commit`        | This option can be toggled to `true` if you'd prefer to have a single commit on the deployment branch instead of maintaining the full history. **Using this option will also cause any existing history to be wiped from the deployment branch**.                                                                                                                                            | `with` | **No**   |
 | `silent`        | Silences the action output preventing it from displaying git messages.                                                                                                                            | `with` | **No**   |
@@ -224,6 +224,9 @@ jobs:
           branch: gh-pages
           folder: build
           clean: true
+          clean-exclude: |
+            special-file.txt
+            some/*.txt
           ssh: true # SSH must be set to true so the deploy action knows which protocol to deploy with.
 ```
 

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -231,7 +231,6 @@ describe('git', () => {
             email: 'as@cat'
           },
           clean: true,
-          cleanExclude: '["cat", "montezuma"]',
           workspace: 'other',
           isTest: TestFlag.NONE
         })
@@ -244,7 +243,7 @@ describe('git', () => {
       })
     })
 
-    it('should execute commands with clean options stored as an array instead', async () => {
+    it('should execute commands with clean options stored as an array', async () => {
       Object.assign(action, {
         silent: false,
         folder: 'assets',
@@ -267,7 +266,7 @@ describe('git', () => {
       expect(rmRF).toBeCalledTimes(1)
     })
 
-    it('should gracefully handle incorrectly formatted clean exclude items', async () => {
+    it('should gracefully handle target folder', async () => {
       Object.assign(action, {
         silent: false,
         folder: '.',
@@ -277,8 +276,7 @@ describe('git', () => {
         clean: true,
         targetFolder: 'new_folder',
         commitMessage: 'Hello!',
-        isTest: TestFlag.NONE,
-        cleanExclude: '["cat, "montezuma"]' // There is a syntax errror in the string.
+        isTest: TestFlag.NONE
       })
 
       await deploy(action)

--- a/action.yml
+++ b/action.yml
@@ -46,8 +46,8 @@ inputs:
     required: false
     default: 'true'
 
-  CLEAN_EXCLUDE:
-    description: "If you need to use CLEAN but you would like to preserve certain files or folders you can use this option. This should be formatted as an array but stored as a string."
+  clean-exclude:
+    description: "If you need to use CLEAN but you would like to preserve certain files or folders you can use this option. This should contain each pattern as a single line in a multiline string."
     required: false
 
   DRY_RUN:

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,7 +20,7 @@ export interface ActionInterface {
   /** If your project generates hashed files on build you can use this option to automatically delete them from the deployment branch with each deploy. This option can be toggled on by setting it to true. */
   clean?: boolean | null
   /** If you need to use CLEAN but you'd like to preserve certain files or folders you can use this option. */
-  cleanExclude?: string | string[]
+  cleanExclude?: string[]
   /** If you need to customize the commit message for an integration you can do so. */
   commitMessage?: string
   /** The git config email. */
@@ -83,7 +83,9 @@ export const action: ActionInterface = {
   clean: !isNullOrUndefined(getInput('clean'))
     ? getInput('clean').toLowerCase() === 'true'
     : false,
-  cleanExclude: getInput('clean_exclude'),
+  cleanExclude: (getInput('clean-exclude') || '')
+    .split('\n')
+    .filter(l => l !== ''),
   isTest: TestFlag.NONE,
   email: !isNullOrUndefined(getInput('git_config_email'))
     ? getInput('git_config_email')

--- a/src/git.ts
+++ b/src/git.ts
@@ -65,19 +65,8 @@ export async function deploy(action: ActionInterface): Promise<Status> {
     // Ensures that items that need to be excluded from the clean job get parsed.
     let excludes = ''
     if (action.clean && action.cleanExclude) {
-      try {
-        const excludedItems =
-          typeof action.cleanExclude === 'string'
-            ? JSON.parse(action.cleanExclude)
-            : action.cleanExclude
-
-        for (const item of excludedItems) {
-          excludes += `--exclude ${item} `
-        }
-      } catch {
-        info(
-          'There was an error parsing your CLEAN_EXCLUDE items. Please refer to the README for more details. ❌'
-        )
+      for (const item of action.cleanExclude) {
+        excludes += `--exclude ${item} `
       }
     }
 


### PR DESCRIPTION
As this change is subtle, I'm taking the opportunity to change
the underscore for the hyphen, which makes it less likely that
users of this action will just pass in an old json array.

I also contemplated if it's a good idea to try to be backwards compatible, i.e., if it's just a single line, try to parse, etc. I didn't feel good about adding the baggage going forwards, though.