### PR TITLE
[fix] remove rocket symbol from the commit message

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -133,7 +133,7 @@ export async function deploy(action: ActionInterface): Promise<Status> {
       ? (action.commitMessage as string)
       : `Deploying to ${action.branch} from ${action.baseBranch} ${
           process.env.GITHUB_SHA ? `@ ${process.env.GITHUB_SHA}` : ''
-        } 🚀`
+        }`
 
     /*
         Checks to see if the remote exists prior to deploying.


### PR DESCRIPTION
**Description**
The rocket cannot be displayed on simple terminals.  All that's left of it is cryptic fly dirt.

**Testing Instructions**
deploy on gh-pages

**Additional Notes**
![Bildschirmfoto vom 2021-01-28 20-51-06](https://user-images.githubusercontent.com/554536/106191047-47ac4300-61a2-11eb-863d-64a9b5f06ce8.png)

