### PR TITLE
[Issue 593] Remote Deployment Issue

### DIFF
--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -44,6 +44,7 @@ describe('git', () => {
       Object.assign(action, {
         silent: false,
         repositoryPath: 'JamesIves/github-pages-deploy-action',
+        isCrossRepositoryDeployment: false,
         token: '123',
         branch: 'branch',
         folder: '.',
@@ -66,6 +67,7 @@ describe('git', () => {
       Object.assign(action, {
         silent: false,
         repositoryPath: 'JamesIves/github-pages-deploy-action',
+        isCrossRepositoryDeployment: false,
         token: '123',
         branch: 'branch',
         folder: '.',
@@ -89,6 +91,7 @@ describe('git', () => {
       Object.assign(action, {
         silent: false,
         repositoryPath: 'JamesIves/github-pages-deploy-action',
+        isCrossRepositoryDeployment: false,
         token: '123',
         branch: 'branch',
         folder: '.',
@@ -110,6 +113,7 @@ describe('git', () => {
       Object.assign(action, {
         silent: false,
         repositoryPath: 'JamesIves/github-pages-deploy-action',
+        isCrossRepositoryDeployment: false,
         sshKey: true,
         branch: 'branch',
         folder: '.',
@@ -130,6 +134,7 @@ describe('git', () => {
       Object.assign(action, {
         silent: false,
         repositoryPath: 'JamesIves/github-pages-deploy-action',
+        isCrossRepositoryDeployment: false,
         token: '123',
         branch: 'branch',
         folder: '.',
@@ -153,6 +158,7 @@ describe('git', () => {
         branch: 'branch',
         token: '123',
         repositoryName: 'JamesIves/montezuma',
+        isCrossRepositoryDeployment: true,
         pusher: {
           name: 'asd',
           email: 'as@cat'
@@ -163,13 +169,14 @@ describe('git', () => {
       const response = await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toBeCalledTimes(11)
+      expect(execute).toBeCalledTimes(12)
       expect(rmRF).toBeCalledTimes(1)
       expect(response).toBe(Status.SUCCESS)
     })
 
     it('should not push when asked to dryRun', async () => {
       Object.assign(action, {
+        isCrossRepositoryDeployment: false,
         silent: false,
         dryRun: true,
         folder: 'assets',
@@ -192,6 +199,7 @@ describe('git', () => {
 
     it('should execute commands with single commit toggled', async () => {
       Object.assign(action, {
+        isCrossRepositoryDeployment: false,
         silent: false,
         folder: 'other',
         folderPath: 'other',
@@ -215,6 +223,7 @@ describe('git', () => {
 
     it('should execute commands with single commit toggled and existing branch', async () => {
       Object.assign(action, {
+        isCrossRepositoryDeployment: false,
         silent: false,
         folder: 'other',
         folderPath: 'other',
@@ -238,6 +247,7 @@ describe('git', () => {
 
     it('should execute commands with single commit and dryRun toggled', async () => {
       Object.assign(action, {
+        isCrossRepositoryDeployment: false,
         silent: false,
         folder: 'other',
         folderPath: 'other',
@@ -270,6 +280,7 @@ describe('git', () => {
         })
 
       Object.assign(action, {
+        isCrossRepositoryDeployment: false,
         silent: false,
         folder: 'assets',
         folderPath: 'assets',
@@ -300,6 +311,7 @@ describe('git', () => {
       it('should execute commands with clean options', async () => {
         process.env.GITHUB_SHA = ''
         Object.assign(action, {
+          isCrossRepositoryDeployment: false,
           silent: false,
           folder: 'other',
           folderPath: 'other',
@@ -324,6 +336,7 @@ describe('git', () => {
 
     it('should execute commands with clean options stored as an array', async () => {
       Object.assign(action, {
+        isCrossRepositoryDeployment: false,
         silent: false,
         folder: 'assets',
         folderPath: 'assets',
@@ -347,6 +360,7 @@ describe('git', () => {
 
     it('should gracefully handle target folder', async () => {
       Object.assign(action, {
+        isCrossRepositoryDeployment: false,
         silent: false,
         folder: '.',
         branch: 'branch',
@@ -367,6 +381,7 @@ describe('git', () => {
 
     it('should stop early if there is nothing to commit', async () => {
       Object.assign(action, {
+        isCrossRepositoryDeployment: false,
         silent: false,
         folder: 'assets',
         branch: 'branch',
@@ -390,6 +405,7 @@ describe('git', () => {
       })
 
       Object.assign(action, {
+        isCrossRepositoryDeployment: false,
         silent: false,
         folder: 'assets',
         branch: 'branch',

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -38,6 +38,7 @@ describe('main', () => {
   it('should run through the commands', async () => {
     Object.assign(action, {
       repositoryPath: 'JamesIves/github-pages-deploy-action',
+      isCrossRepositoryDeployment: false,
       folder: 'assets',
       branch: 'branch',
       token: '123',
@@ -49,7 +50,7 @@ describe('main', () => {
       debug: true
     })
     await run(action)
-    expect(execute).toBeCalledTimes(13)
+    expect(execute).toBeCalledTimes(12)
     expect(rmRF).toBeCalledTimes(1)
     expect(exportVariable).toBeCalledTimes(1)
   })
@@ -57,6 +58,7 @@ describe('main', () => {
   it('should run through the commands and succeed', async () => {
     Object.assign(action, {
       repositoryPath: 'JamesIves/github-pages-deploy-action',
+      isCrossRepositoryDeployment: false,
       folder: 'assets',
       branch: 'branch',
       token: '123',
@@ -75,6 +77,7 @@ describe('main', () => {
 
   it('should throw if an error is encountered', async () => {
     Object.assign(action, {
+      isCrossRepositoryDeployment: false,
       folder: 'assets',
       branch: 'branch',
       token: null,

--- a/__tests__/ssh.test.ts
+++ b/__tests__/ssh.test.ts
@@ -43,6 +43,7 @@ describe('configureSSH', () => {
 
   it('should skip client configuration if sshKey is set to true', async () => {
     Object.assign(action, {
+      isCrossRepositoryDeployment: false,
       silent: false,
       folder: 'assets',
       branch: 'branch',
@@ -67,6 +68,7 @@ describe('configureSSH', () => {
     })
 
     Object.assign(action, {
+      isCrossRepositoryDeployment: false,
       silent: false,
       folder: 'assets',
       branch: 'branch',
@@ -91,6 +93,7 @@ describe('configureSSH', () => {
     })
 
     Object.assign(action, {
+      isCrossRepositoryDeployment: false,
       silent: false,
       folder: 'assets',
       branch: 'branch',
@@ -115,6 +118,7 @@ describe('configureSSH', () => {
     })
 
     Object.assign(action, {
+      isCrossRepositoryDeployment: false,
       silent: false,
       folder: 'assets',
       branch: 'branch',

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -35,6 +35,7 @@ describe('util', () => {
     it('should return ssh if ssh is provided', async () => {
       const action = {
         branch: '123',
+        isCrossRepositoryDeployment: false,
         workspace: 'src/',
         folder: 'build',
         token: null,
@@ -48,6 +49,7 @@ describe('util', () => {
     it('should return deploy token if token is provided', async () => {
       const action = {
         branch: '123',
+        isCrossRepositoryDeployment: false,
         workspace: 'src/',
         folder: 'build',
         token: '123',
@@ -61,6 +63,7 @@ describe('util', () => {
     it('should return ... if no token is provided', async () => {
       const action = {
         branch: '123',
+        isCrossRepositoryDeployment: false,
         workspace: 'src/',
         folder: 'build',
         token: null,
@@ -76,6 +79,7 @@ describe('util', () => {
     it('should return ssh if ssh is provided', async () => {
       const action = {
         repositoryName: 'JamesIves/github-pages-deploy-action',
+        isCrossRepositoryDeployment: true,
         branch: '123',
         workspace: 'src/',
         folder: 'build',
@@ -92,6 +96,7 @@ describe('util', () => {
     it('should return https with x-access-token if deploy token is provided', async () => {
       const action = {
         repositoryName: 'JamesIves/github-pages-deploy-action',
+        isCrossRepositoryDeployment: true,
         branch: '123',
         workspace: 'src/',
         folder: 'build',
@@ -109,6 +114,7 @@ describe('util', () => {
       it('should replace any sensitive information with ***', async () => {
         const action = {
           repositoryName: 'JamesIves/github-pages-deploy-action',
+          isCrossRepositoryDeployment: true,
           repositoryPath:
             'https://x-access-token:supersecret999%%%@github.com/anothersecret123333',
           branch: '123',
@@ -128,6 +134,7 @@ describe('util', () => {
       it('should not suppress information when in debug mode', async () => {
         const action = {
           repositoryName: 'JamesIves/github-pages-deploy-action',
+          isCrossRepositoryDeployment: true,
           repositoryPath:
             'https://x-access-token:supersecret999%%%@github.com/anothersecret123333',
           branch: '123',
@@ -151,6 +158,7 @@ describe('util', () => {
   describe('generateFolderPath', () => {
     it('should return absolute path if folder name is provided', () => {
       const action = {
+        isCrossRepositoryDeployment: false,
         branch: '123',
         workspace: 'src/',
         folder: 'build',
@@ -164,6 +172,7 @@ describe('util', () => {
 
     it('should return original path if folder name begins with /', () => {
       const action = {
+        isCrossRepositoryDeployment: false,
         branch: '123',
         workspace: 'src/',
         folder: '/home/user/repo/build',
@@ -177,6 +186,7 @@ describe('util', () => {
 
     it('should process as relative path if folder name begins with ./', () => {
       const action = {
+        isCrossRepositoryDeployment: false,
         branch: '123',
         workspace: 'src/',
         folder: './build',
@@ -190,6 +200,7 @@ describe('util', () => {
 
     it('should return absolute path if folder name begins with ~', () => {
       const action = {
+        isCrossRepositoryDeployment: false,
         branch: '123',
         workspace: 'src/',
         folder: '~/repo/build',
@@ -206,6 +217,7 @@ describe('util', () => {
   describe('hasRequiredParameters', () => {
     it('should fail if there is no provided GitHub Token, Access Token or SSH bool', () => {
       const action = {
+        isCrossRepositoryDeployment: false,
         silent: false,
         repositoryPath: undefined,
         branch: 'branch',
@@ -225,6 +237,7 @@ describe('util', () => {
 
     it('should fail if token is defined but it is an empty string', () => {
       const action = {
+        isCrossRepositoryDeployment: false,
         silent: false,
         repositoryPath: undefined,
         token: '',
@@ -245,6 +258,7 @@ describe('util', () => {
 
     it('should fail if there is no branch', () => {
       const action = {
+        isCrossRepositoryDeployment: false,
         silent: false,
         repositoryPath: undefined,
         token: '123',
@@ -263,6 +277,7 @@ describe('util', () => {
 
     it('should fail if there is no folder', () => {
       const action = {
+        isCrossRepositoryDeployment: false,
         silent: false,
         repositoryPath: undefined,
         token: '123',
@@ -283,6 +298,7 @@ describe('util', () => {
 
     it('should fail if the folder does not exist in the tree', () => {
       const action: ActionInterface = {
+        isCrossRepositoryDeployment: false,
         silent: false,
         repositoryPath: undefined,
         token: '123',

--- a/__tests__/worktree.error.test.ts
+++ b/__tests__/worktree.error.test.ts
@@ -21,6 +21,7 @@ describe('generateWorktree', () => {
           branch: 'gh-pages',
           folder: '',
           silent: true,
+          isCrossRepositoryDeployment: false,
           isTest: TestFlag.HAS_CHANGED_FILES
         },
         'worktree',

--- a/__tests__/worktree.test.ts
+++ b/__tests__/worktree.test.ts
@@ -277,5 +277,4 @@ describe('generateWorktree', () => {
       expect(commitMessages).toBe('gh1')
     })
   })
-
 })

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "rimraf lib && tsc --declaration",
     "test": "jest",
+    "test:clear": "jest --clearCache",
     "lint": "eslint src/**/*.ts __tests__/**/*.ts",
     "format": "prettier --write './**/*.ts'"
   },

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,6 +39,8 @@ export interface ActionInterface {
   repositoryName?: string
   /** The fully qualified repositpory path, this gets auto generated if repositoryName is provided. */
   repositoryPath?: string
+  /** Determines if the action is performing a cross repository deployment or not. */
+  isCrossRepositoryDeployment: boolean
   /** Wipes the commit history from the deployment branch in favor of a single commit. */
   singleCommit?: boolean | null
   /** Determines if the action should run in silent mode or not. */
@@ -109,6 +111,7 @@ export const action: ActionInterface = {
     : repository && repository.full_name
     ? repository.full_name
     : process.env.GITHUB_REPOSITORY,
+  isCrossRepositoryDeployment: !isNullOrUndefined(getInput('repository-name')),
   token: getInput('token'),
   singleCommit: !isNullOrUndefined(getInput('single-commit'))
     ? getInput('single-commit').toLowerCase() === 'true'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -75,6 +75,8 @@ export interface NodeActionInterface {
   workspace: string
   /** Determines test scenarios the action is running in. */
   isTest: TestFlag
+  /** Determines if the action is performing a cross repository deployment or not. */
+  isCrossRepositoryDeployment?: boolean
 }
 
 /* Required action data that gets initialized when running within the GitHub Actions environment. */

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -33,7 +33,7 @@ export async function generateWorktree(
     if (branchExists) {
       await execute(
         `git fetch --no-recurse-submodules --depth=1 ${
-          action.repositoryName ? action.repositoryPath : 'origin'
+          action.isCrossRepositoryDeployment ? action.repositoryPath : 'origin'
         } ${action.branch}`,
         action.workspace,
         action.silent
@@ -57,7 +57,7 @@ export async function generateWorktree(
       checkout.orphan = true
     }
 
-    if (action.repositoryName) {
+    if (action.isCrossRepositoryDeployment) {
       // Used when cross repo deploying to ensure that context is focused on the correct remote.
       await execute(`git fetch`, action.workspace, action.silent)
     }
@@ -85,6 +85,7 @@ export async function generateWorktree(
       }
     }
   } catch (error) {
+    console.log(error)
     throw new Error(
       `There was an error creating the worktree: ${suppressSensitiveInformation(
         error.message,

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -32,7 +32,9 @@ export async function generateWorktree(
 
     if (branchExists) {
       await execute(
-        `git fetch --no-recurse-submodules --depth=1 origin ${action.branch}`,
+        `git fetch --no-recurse-submodules --depth=1 ${
+          action.repositoryName ? action.repositoryPath : 'origin'
+        } ${action.branch}`,
         action.workspace,
         action.silent
       )
@@ -44,14 +46,22 @@ export async function generateWorktree(
       action.silent
     )
     const checkout = new GitCheckout(action.branch)
+
     if (branchExists) {
       // There's existing data on the branch to check out
       checkout.commitish = `origin/${action.branch}`
     }
+
     if (!branchExists || action.singleCommit) {
       // Create a new history if we don't have the branch, or if we want to reset it
       checkout.orphan = true
     }
+
+    if (action.repositoryName) {
+      // Used when cross repo deploying to ensure that context is focused on the correct remote.
+      await execute(`git fetch`, action.workspace, action.silent)
+    }
+
     await execute(
       checkout.toString(),
       `${action.workspace}/${worktreedir}`,


### PR DESCRIPTION
## Description 

Makes an adjustment to two git commands if `repository-name` is defined or not. Allowing proper cross repo deploying in v4.  This issue has honestly stumped me, and I'm really not sure why this works, but it does, especially as `git fetch` is called previously with the remote repo url. Maybe running `git fetch` adjusts the git config? I need more coffee lol

- [X] Deploys if gh-pages does not exist in originating repo.
- [X] Deploys if gh-pages does exist in originating repo.
- [X] Deploys if gh-pages does not exist in target repo.
- [X] Deploys if gh-pages does exist in target repo.
- [X] Does not effect other other deployment methods. 

## Testing Instructions

* Try this on `releases/v4-beta`.
* Example: https://github.com/JamesIves/lab/tree/gh-pages

## Additional Notes

Having a tough time getting the worktree tests to pass however, may need a hand with that.