### PR TITLE
Enables Support for Self-Hosted GitHub Instances (GitHub Enterprise)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 </p>
 
 <p align="center">
-  This <a href="https://github.com/features/actions">GitHub Action</a> will automatically deploy your project to <a href="https://pages.github.com/">GitHub Pages</a>. It can be configured to push your production-ready code into any branch you'd like, including <b>gh-pages</b> and <b>docs</b>. It can also handle cross repository deployments and works with [GitHub Enterprise](https://github.com/enterprise) too.
+  This <a href="https://github.com/features/actions">GitHub Action</a> will automatically deploy your project to <a href="https://pages.github.com/">GitHub Pages</a>. It can be configured to push your production-ready code into any branch you'd like, including <b>gh-pages</b> and <b>docs</b>. It can also handle cross repository deployments and works with <a href="https://github.com/enterprise">GitHub Enterprise</a> too.
 </p>
 
 <p align="center">

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 </p>
 
 <p align="center">
-  This <a href="https://github.com/features/actions">GitHub Action</a> will automatically deploy your project to <a href="https://pages.github.com/">GitHub Pages</a>. It can be configured to push your production-ready code into any branch you'd like, including <b>gh-pages</b> and <b>docs</b>. It can also handle cross repository deployments too.
+  This <a href="https://github.com/features/actions">GitHub Action</a> will automatically deploy your project to <a href="https://pages.github.com/">GitHub Pages</a>. It can be configured to push your production-ready code into any branch you'd like, including <b>gh-pages</b> and <b>docs</b>. It can also handle cross repository deployments and works with [GitHub Enterprise](https://github.com/enterprise) too.
 </p>
 
 <p align="center">

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -42,6 +42,7 @@ describe('git', () => {
   describe('init', () => {
     it('should execute commands', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         repositoryPath: 'JamesIves/github-pages-deploy-action',
         token: '123',
@@ -64,6 +65,7 @@ describe('git', () => {
       })
 
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         repositoryPath: 'JamesIves/github-pages-deploy-action',
         token: '123',
@@ -87,6 +89,7 @@ describe('git', () => {
 
     it('should correctly continue when it cannot unset a git config value', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         repositoryPath: 'JamesIves/github-pages-deploy-action',
         token: '123',
@@ -108,6 +111,7 @@ describe('git', () => {
       process.env.CI = 'true'
 
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         repositoryPath: 'JamesIves/github-pages-deploy-action',
         sshKey: true,
@@ -128,6 +132,7 @@ describe('git', () => {
 
     it('should correctly continue when it cannot remove origin', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         repositoryPath: 'JamesIves/github-pages-deploy-action',
         token: '123',
@@ -148,6 +153,7 @@ describe('git', () => {
   describe('deploy', () => {
     it('should execute commands', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         folder: 'assets',
         branch: 'branch',
@@ -170,6 +176,7 @@ describe('git', () => {
 
     it('should not push when asked to dryRun', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         dryRun: true,
         folder: 'assets',
@@ -192,6 +199,7 @@ describe('git', () => {
 
     it('should execute commands with single commit toggled', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         folder: 'other',
         folderPath: 'other',
@@ -215,6 +223,7 @@ describe('git', () => {
 
     it('should execute commands with single commit toggled and existing branch', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         folder: 'other',
         folderPath: 'other',
@@ -238,6 +247,7 @@ describe('git', () => {
 
     it('should execute commands with single commit and dryRun toggled', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         folder: 'other',
         folderPath: 'other',
@@ -270,6 +280,7 @@ describe('git', () => {
         })
 
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         folder: 'assets',
         folderPath: 'assets',
@@ -300,6 +311,7 @@ describe('git', () => {
       it('should execute commands with clean options', async () => {
         process.env.GITHUB_SHA = ''
         Object.assign(action, {
+          hostname: 'github.com',
           silent: false,
           folder: 'other',
           folderPath: 'other',
@@ -324,6 +336,7 @@ describe('git', () => {
 
     it('should execute commands with clean options stored as an array', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         folder: 'assets',
         folderPath: 'assets',
@@ -347,6 +360,7 @@ describe('git', () => {
 
     it('should gracefully handle target folder', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         folder: '.',
         branch: 'branch',
@@ -367,6 +381,7 @@ describe('git', () => {
 
     it('should stop early if there is nothing to commit', async () => {
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         folder: 'assets',
         branch: 'branch',
@@ -390,6 +405,7 @@ describe('git', () => {
       })
 
       Object.assign(action, {
+        hostname: 'github.com',
         silent: false,
         folder: 'assets',
         branch: 'branch',

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -41,6 +41,7 @@ describe('main', () => {
       folder: 'assets',
       branch: 'branch',
       token: '123',
+      hostname: 'github.com',
       pusher: {
         name: 'asd',
         email: 'as@cat'
@@ -49,13 +50,14 @@ describe('main', () => {
       debug: true
     })
     await run(action)
-    expect(execute).toBeCalledTimes(13)
+    expect(execute).toBeCalledTimes(12)
     expect(rmRF).toBeCalledTimes(1)
     expect(exportVariable).toBeCalledTimes(1)
   })
 
   it('should run through the commands and succeed', async () => {
     Object.assign(action, {
+      hostname: 'github.com',
       repositoryPath: 'JamesIves/github-pages-deploy-action',
       folder: 'assets',
       branch: 'branch',
@@ -75,6 +77,7 @@ describe('main', () => {
 
   it('should throw if an error is encountered', async () => {
     Object.assign(action, {
+      hostname: 'github.com',
       folder: 'assets',
       branch: 'branch',
       token: null,

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -50,7 +50,7 @@ describe('main', () => {
       debug: true
     })
     await run(action)
-    expect(execute).toBeCalledTimes(12)
+    expect(execute).toBeCalledTimes(13)
     expect(rmRF).toBeCalledTimes(1)
     expect(exportVariable).toBeCalledTimes(1)
   })

--- a/__tests__/ssh.test.ts
+++ b/__tests__/ssh.test.ts
@@ -43,6 +43,7 @@ describe('configureSSH', () => {
 
   it('should skip client configuration if sshKey is set to true', async () => {
     Object.assign(action, {
+      hostname: 'github.com',
       silent: false,
       folder: 'assets',
       branch: 'branch',
@@ -67,6 +68,7 @@ describe('configureSSH', () => {
     })
 
     Object.assign(action, {
+      hostname: 'github.com',
       silent: false,
       folder: 'assets',
       branch: 'branch',
@@ -91,6 +93,7 @@ describe('configureSSH', () => {
     })
 
     Object.assign(action, {
+      hostname: 'github.com',
       silent: false,
       folder: 'assets',
       branch: 'branch',
@@ -115,6 +118,7 @@ describe('configureSSH', () => {
     })
 
     Object.assign(action, {
+      hostname: 'github.com',
       silent: false,
       folder: 'assets',
       branch: 'branch',

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -5,7 +5,8 @@ import {
   generateRepositoryPath,
   generateFolderPath,
   suppressSensitiveInformation,
-  checkParameters
+  checkParameters,
+  stripProtocolFromUrl
 } from '../src/util'
 
 describe('util', () => {
@@ -79,11 +80,13 @@ describe('util', () => {
         branch: '123',
         workspace: 'src/',
         folder: 'build',
+        hostname: 'github.com',
         token: null,
         sshKey: 'real_token',
         silent: false,
         isTest: TestFlag.NONE
       }
+
       expect(generateRepositoryPath(action)).toEqual(
         'git@github.com:JamesIves/github-pages-deploy-action'
       )
@@ -95,13 +98,15 @@ describe('util', () => {
         branch: '123',
         workspace: 'src/',
         folder: 'build',
+        hostname: 'enterprise.github.com',
         token: '123',
         sshKey: null,
         silent: false,
         isTest: TestFlag.NONE
       }
+
       expect(generateRepositoryPath(action)).toEqual(
-        'https://x-access-token:123@github.com/JamesIves/github-pages-deploy-action.git'
+        'https://x-access-token:123@enterprise.github.com/JamesIves/github-pages-deploy-action.git'
       )
     })
 
@@ -300,6 +305,26 @@ describe('util', () => {
           `The directory you're trying to deploy named notARealFolder doesn't exist. Please double check the path and any prerequisite build scripts and try again. ❗`
         )
       }
+    })
+  })
+
+  describe('stripProtocolFromUrl', () => {
+    it('removes https', () => {
+      expect(stripProtocolFromUrl('https://github.com')).toBe('github.com')
+    })
+
+    it('removes http', () => {
+      expect(stripProtocolFromUrl('http://github.com')).toBe('github.com')
+    })
+
+    it('removes https|http and www.', () => {
+      expect(stripProtocolFromUrl('http://www.github.com')).toBe('github.com')
+    })
+
+    it('works with a url that is not github.com', () => {
+      expect(stripProtocolFromUrl('http://github.enterprise.jamesiv.es')).toBe(
+        'github.enterprise.jamesiv.es'
+      )
     })
   })
 })

--- a/__tests__/worktree.error.test.ts
+++ b/__tests__/worktree.error.test.ts
@@ -16,6 +16,7 @@ describe('generateWorktree', () => {
     try {
       await generateWorktree(
         {
+          hostname: 'github.com',
           workspace: 'somewhere',
           singleCommit: false,
           branch: 'gh-pages',

--- a/__tests__/worktree.test.ts
+++ b/__tests__/worktree.test.ts
@@ -81,6 +81,7 @@ describe('generateWorktree', () => {
       const workspace = clonedir as string
       await generateWorktree(
         {
+          hostname: 'github.com',
           workspace,
           singleCommit: false,
           branch: 'gh-pages',
@@ -111,6 +112,7 @@ describe('generateWorktree', () => {
       const workspace = clonedir as string
       await generateWorktree(
         {
+          hostname: 'github.com',
           workspace,
           singleCommit: false,
           branch: 'no-pages',
@@ -138,6 +140,7 @@ describe('generateWorktree', () => {
       const workspace = clonedir as string
       await generateWorktree(
         {
+          hostname: 'github.com',
           workspace,
           singleCommit: true,
           branch: 'gh-pages',
@@ -169,6 +172,7 @@ describe('generateWorktree', () => {
       const workspace = clonedir as string
       await generateWorktree(
         {
+          hostname: 'github.com',
           workspace,
           singleCommit: true,
           branch: 'no-pages',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -99,9 +99,8 @@ export const action: ActionInterface = {
     ? getInput('git-config-email')
     : pusher && pusher.email
     ? pusher.email
-    : `${
-        process.env.GITHUB_ACTOR || 'github-pages-deploy-action'
-      }@users.noreply.${
+    : `${process.env.GITHUB_ACTOR ||
+        'github-pages-deploy-action'}@users.noreply.${
         process.env.GITHUB_SERVER_URL
           ? stripProtocolFromUrl(process.env.GITHUB_SERVER_URL)
           : 'github.com'

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -99,8 +99,9 @@ export const action: ActionInterface = {
     ? getInput('git-config-email')
     : pusher && pusher.email
     ? pusher.email
-    : `${process.env.GITHUB_ACTOR ||
-        'github-pages-deploy-action'}@users.noreply.${
+    : `${
+        process.env.GITHUB_ACTOR || 'github-pages-deploy-action'
+      }@users.noreply.${
         process.env.GITHUB_SERVER_URL
           ? stripProtocolFromUrl(process.env.GITHUB_SERVER_URL)
           : 'github.com'

--- a/src/git.ts
+++ b/src/git.ts
@@ -29,7 +29,7 @@ export async function init(action: ActionInterface): Promise<void | Error> {
           Only runs in the GitHub Actions CI environment if a user is not using an SSH key.
         */
         await execute(
-          `git config --local --unset-all http.https://github.com/.extraheader`,
+          `git config --local --unset-all http.https://${action.hostname}/.extraheader`,
           action.workspace,
           action.silent
         )

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -12,10 +12,8 @@ export async function configureSSH(action: ActionInterface): Promise<void> {
       const sshKnownHostsDirectory = `${sshDirectory}/known_hosts`
 
       // SSH fingerprints provided by GitHub: https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/githubs-ssh-key-fingerprints
-      const sshGitHubKnownHostRsa =
-        '\ngithub.com ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==\n'
-      const sshGitHubKnownHostDss =
-        '\ngithub.com ssh-dss AAAAB3NzaC1kc3MAAACBANGFW2P9xlGU3zWrymJgI/lKo//ZW2WfVtmbsUZJ5uyKArtlQOT2+WRhcg4979aFxgKdcsqAYW3/LS1T2km3jYW/vr4Uzn+dXWODVk5VlUiZ1HFOHf6s6ITcZvjvdbp6ZbpM+DuJT7Bw+h5Fx8Qt8I16oCZYmAPJRtu46o9C2zk1AAAAFQC4gdFGcSbp5Gr0Wd5Ay/jtcldMewAAAIATTgn4sY4Nem/FQE+XJlyUQptPWMem5fwOcWtSXiTKaaN0lkk2p2snz+EJvAGXGq9dTSWHyLJSM2W6ZdQDqWJ1k+cL8CARAqL+UMwF84CR0m3hj+wtVGD/J4G5kW2DBAf4/bqzP4469lT+dF2FRQ2L9JKXrCWcnhMtJUvua8dvnwAAAIB6C4nQfAA7x8oLta6tT+oCk2WQcydNsyugE8vLrHlogoWEicla6cWPk7oXSspbzUcfkjN3Qa6e74PhRkc7JdSdAlFzU3m7LMkXo1MHgkqNX8glxWNVqBSc0YRdbFdTkL0C6gtpklilhvuHQCdbgB3LBAikcRkDp+FCVkUgPC/7Rw==\n'
+      const sshGitHubKnownHostRsa = `\n${action.hostname} ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==\n`
+      const sshGitHubKnownHostDss = `\n${action.hostname} ssh-dss AAAAB3NzaC1kc3MAAACBANGFW2P9xlGU3zWrymJgI/lKo//ZW2WfVtmbsUZJ5uyKArtlQOT2+WRhcg4979aFxgKdcsqAYW3/LS1T2km3jYW/vr4Uzn+dXWODVk5VlUiZ1HFOHf6s6ITcZvjvdbp6ZbpM+DuJT7Bw+h5Fx8Qt8I16oCZYmAPJRtu46o9C2zk1AAAAFQC4gdFGcSbp5Gr0Wd5Ay/jtcldMewAAAIATTgn4sY4Nem/FQE+XJlyUQptPWMem5fwOcWtSXiTKaaN0lkk2p2snz+EJvAGXGq9dTSWHyLJSM2W6ZdQDqWJ1k+cL8CARAqL+UMwF84CR0m3hj+wtVGD/J4G5kW2DBAf4/bqzP4469lT+dF2FRQ2L9JKXrCWcnhMtJUvua8dvnwAAAIB6C4nQfAA7x8oLta6tT+oCk2WQcydNsyugE8vLrHlogoWEicla6cWPk7oXSspbzUcfkjN3Qa6e74PhRkc7JdSdAlFzU3m7LMkXo1MHgkqNX8glxWNVqBSc0YRdbFdTkL0C6gtpklilhvuHQCdbgB3LBAikcRkDp+FCVkUgPC/7Rw==\n`
 
       info(`Configuring SSH client… 🔑`)
 

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -23,7 +23,9 @@ export async function configureSSH(action: ActionInterface): Promise<void> {
       appendFileSync(sshKnownHostsDirectory, sshGitHubKnownHostDss)
 
       // Initializes SSH agent.
-      const agentOutput = execFileSync('ssh-agent').toString().split('\n')
+      const agentOutput = execFileSync('ssh-agent')
+        .toString()
+        .split('\n')
 
       agentOutput.map(line => {
         const exportableVariables = /^(SSH_AUTH_SOCK|SSH_AGENT_PID)=(.*); export \1/.exec(

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -23,9 +23,7 @@ export async function configureSSH(action: ActionInterface): Promise<void> {
       appendFileSync(sshKnownHostsDirectory, sshGitHubKnownHostDss)
 
       // Initializes SSH agent.
-      const agentOutput = execFileSync('ssh-agent')
-        .toString()
-        .split('\n')
+      const agentOutput = execFileSync('ssh-agent').toString().split('\n')
 
       agentOutput.map(line => {
         const exportableVariables = /^(SSH_AUTH_SOCK|SSH_AGENT_PID)=(.*); export \1/.exec(

--- a/src/util.ts
+++ b/src/util.ts
@@ -18,8 +18,8 @@ export const generateTokenType = (action: ActionInterface): string =>
 /* Generates a the repository path used to make the commits. */
 export const generateRepositoryPath = (action: ActionInterface): string =>
   action.sshKey
-    ? `git@github.com:${action.repositoryName}`
-    : `https://${`x-access-token:${action.token}`}@github.com/${
+    ? `git@${action.hostname}:${action.repositoryName}`
+    : `https://${`x-access-token:${action.token}`}@${action.hostname}/${
         action.repositoryName
       }.git`
 
@@ -89,3 +89,7 @@ export const suppressSensitiveInformation = (
 
   return value
 }
+
+/** Strips the protocol from a provided URL. */
+export const stripProtocolFromUrl = (url: string): string =>
+  url.replace(/^(?:https?:\/\/)?(?:www\.)?/i, '').split('/')[0]


### PR DESCRIPTION
## Description
<!-- Provide a description of what your changes do. -->

Currently this action only deploys to github.com sites which is not ideal if you're using a self-hosted instance of GitHub Enterprise. With this change the action now reads from `process.env.GITHUB_SERVER_URL` and context switches to the url provided by the action before deploying: https://docs.github.com/en/actions/reference/environment-variables. This means that the action will be able to deploy within an on-prem instance of GitHub. 

Unless we end up with a lot of requests I don't think it makes sense to allow users to customize this value, the provided environment variable should be good enough in terms of ensuring it's deploying within the correct GitHub host. 

## Testing Instructions
<!-- Give us step by step instructions on how to test your changes. -->

* It should work as before for regular users as this value defaults to `https://github.com`.
* If you have an on-prem instance, try it out! 
* Available on `releases/v4-beta`.

## Additional Notes
<!-- Anything else that will help us test the pull request. -->

N/A