### PR TITLE
use "npm ci" instead of "npm install" in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Deploy 🚀
@@ -203,7 +203,7 @@ jobs:
 
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Deploy 🚀
@@ -252,7 +252,7 @@ jobs:
 
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Upload Artifacts 🔺 # The project is then uploaded as an artifact named 'site'.
@@ -322,7 +322,7 @@ jobs:
 
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
-          npm install
+          npm ci
           npm run build
 
       - name: Deploy 🚀


### PR DESCRIPTION
## Description

In the readme examples, use [npm ci](https://docs.npmjs.com/cli/v8/commands/npm-ci) instead of `npm install`

## Testing Instructions

Look at the readme 😃 

## Additional Notes

`npm ci` is the more appropriate command for CI environments. For example, it will always install the dependencies as defined in the lockfile
