### PR TITLE
Add preCommitScript option

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -43,6 +43,10 @@ inputs:
     description: 'If you would like to push the contents of the deployment folder into a specific directory on the deployment branch you can specify it here.'
     required: false
 
+  pre-commit:
+    description: 'Shell script to run before the new commit is created.'
+    required: false
+
   commit-message:
     description: 'If you need to customize the commit message for an integration you can do so.'
     required: false

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -37,6 +37,8 @@ export interface ActionInterface {
   isTest: TestFlag
   /** The git config name. */
   name?: string
+  /** Shell script to run before creating a new commit containing the target folder */
+  preCommitScript?: string
   /** The repository path, for example JamesIves/github-pages-deploy-action. */
   repositoryName?: string
   /** The fully qualified repositpory path, this gets auto generated if repositoryName is provided. */
@@ -132,6 +134,7 @@ export const action: ActionInterface = {
     ? true
     : getInput('ssh-key'),
   targetFolder: getInput('target-folder'),
+  preCommitScript: getInput('pre-commit'),
   workspace: process.env.GITHUB_WORKSPACE || ''
 }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -2,13 +2,14 @@ import {info} from '@actions/core'
 import {mkdirP, rmRF} from '@actions/io'
 import fs from 'fs'
 import {ActionInterface, Status, TestFlag} from './constants'
-import {execute} from './execute'
+import {execute, stdout} from './execute'
 import {generateWorktree} from './worktree'
 import {
   extractErrorMessage,
   isNullOrUndefined,
   suppressSensitiveInformation
 } from './util'
+import {exec} from '@actions/exec'
 
 /* Initializes git in the workspace. */
 export async function init(action: ActionInterface): Promise<void | Error> {
@@ -146,6 +147,14 @@ export async function deploy(action: ActionInterface): Promise<Status> {
       action.workspace,
       action.silent
     )
+
+    if (action.preCommitScript) {
+      await exec('bash', ['-c', action.preCommitScript], {
+        listeners: {stdout},
+        silent: action.silent,
+        cwd: `${action.workspace}/${temporaryDeploymentDirectory}`
+      })
+    }
 
     if (action.singleCommit) {
       await execute(


### PR DESCRIPTION
## Description

Self-describing feature. Usecase: I'm using this action to deploy new versions of a specification I'm working on to a release branch. Old versions of the spec need to continuously be available so I deploy each new release to a subdirectory named after the release version.

The problem I ran into was the inability to generate a static HTML directory listing (using `tree`) before the new commit is made. I could do it with a github action whenever the release branch is updated, but that would be a pain, so I added this feature instead.

## Testing Instructions

`jest`
