### PR TITLE
lib.ts: adjust status logging levels

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -73,16 +73,13 @@ export default async function run(
 
     setFailed(extractErrorMessage(error))
   } finally {
-    const terminationMessage = `${
-      status === Status.FAILED
-        ? 'Deployment failed! ❌'
-        : status === Status.SUCCESS
-        ? 'Completed deployment successfully! ✅'
-        : 'There is nothing to commit. Exiting early… 📭'
-    }`
-
-    info(terminationMessage)
-    notice(terminationMessage)
+    if (status === Status.FAILED) {
+      notice('Deployment failed! ❌')
+    } else if (status === Status.SUCCESS) {
+      info('Completed deployment successfully! ✅')
+    } else {
+      info('There is nothing to commit. Exiting early… 📭')
+    }
 
     exportVariable('deployment_status', status)
     setOutput('deployment-status', status)


### PR DESCRIPTION
GitHub reports when workflow runs log messages with `notice` or higher
logging levels, e.g.:

> There are 0 failures, 0 warnings, and 1 notices.

Since `notice` was being used regardless of status, these reports were
misleading, because everything was working correctly on successes and 
no-ops.

Therefore, the successes and no-ops now only log with `info`, and the 
failures now only log with `notice`.

## Description

<!-- Provide a description of what your changes do. -->

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->

## Additional Notes

<!-- Anything else that will help us test the pull request. -->
