### PR TITLE
Fix failing tests when not running on Actions

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -4,6 +4,7 @@ process.env['GITHUB_SHA'] = '123'
 process.env['INPUT_DEBUG'] = 'debug'
 process.env['GITHUB_REF_NAME'] = 'test'
 process.env['RUNNER_OS'] = 'Linux'
+process.env['CI'] = 'true'
 
 import '../src/main'
 import {action, TestFlag} from '../src/constants'


### PR DESCRIPTION
Tests expect `execute` to be called 16 times:

https://github.com/JamesIves/github-pages-deploy-action/blob/226f2c44b58c32b6f07f5835346633e66fc069db/__tests__/main.test.ts#L55

One such call only occurs when env var `CI` is truthy:

https://github.com/JamesIves/github-pages-deploy-action/blob/226f2c44b58c32b6f07f5835346633e66fc069db/src/git.ts#L43-L47

[This env var is always set to `true` during an Actions run](https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables), but is not true when running tests locally. In this case, `execute` is called 15 times, causing tests to fail.

This PR resolves this by setting `CI` to true during test init.