### PR TITLE
Add option to specify `CNAME` in actions file

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -203,6 +203,32 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           branches: gh-pages
 
+  # Deploys using the CNAME option.
+  integration-cname:
+    needs:
+      [
+        integration-checkout-v1,
+        integration-checkout-v2,
+        integration-container,
+        integration-ssh,
+        integration-ssh-third-party-client,
+        integration-env
+      ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+
+      - name: Build and Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          token: ${{ secrets.ACCESS_TOKEN }}
+          folder: integration
+          cname: 'test.com'
+          silent: true
+
   # Deploys using the CLEAN option.
   integration-clean:
     needs:

--- a/README.md
+++ b/README.md
@@ -330,8 +330,6 @@ jobs:
 </p>
 </details>
 
-If you wish to remove these files you must go into the deployment branch directly to remove them. This is to prevent accidental changes in your deployment script from creating breaking changes.
-
 Alternatively, you have the option to specify `CNAME` address so that you don't need upload the `CNAME` file manually.
 
 ```yml
@@ -340,3 +338,5 @@ Alternatively, you have the option to specify `CNAME` address so that you don't 
   with:
     CNAME: example.com
 ```
+
+If you wish to remove these files you must go into the deployment branch directly to remove them. This is to prevent accidental changes in your deployment script from creating breaking changes.

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ By default, the action does not need any token configuration and uses the provid
 | `repository-name`  | Allows you to specify a different repository path so long as you have permissions to push to it. This should be formatted like so: `JamesIves/github-pages-deploy-action`. You'll need to use a PAT in the `token` input for this configuration option to work properly.                                                                                                    | `with` | **No**   |
 | `target-folder`    | If you'd like to push the contents of the deployment folder into a specific directory on the deployment branch you can specify it here.                                                                                                                                                                                                                                     | `with` | **No**   |
 | `commit-message`   | If you need to customize the commit message for an integration you can do so.                                                                                                                                                                                                                                                                                               | `with` | **No**   |
+| `CNAME`            | If you need to add CNAME for setting up custom domain, you can use this option. While deploying, a CNAME file will be created automatically in the deployment branch copying the address specified here.                                                                                                                                                                    | `with` | **No**   |
 | `clean`            | You can use this option to delete files from your deployment destination that no longer exist in your deployment source. One use case is if your project generates hashed files that vary from build to build. Using `clean` will not affect `.git`, `.github`, or `.ssh` directories. This option is turned on by default and can be toggled off by setting it to `false`. | `with` | **No**   |
 | `clean-exclude`    | If you need to use `clean` but you'd like to preserve certain files or folders you can use this option. This should contain each pattern as a single line in a multiline string.                                                                                                                                                                                            | `with` | **No**   |
 | `dry-run`          | Do not actually push back, but use `--dry-run` on `git push` invocations instead.                                                                                                                                                                                                                                                                                           | `with` | **No**   |
@@ -330,3 +331,12 @@ jobs:
 </details>
 
 If you wish to remove these files you must go into the deployment branch directly to remove them. This is to prevent accidental changes in your deployment script from creating breaking changes.
+
+Alternatively, you have the option to specify `CNAME` address so that you don't need upload the `CNAME` file manually.
+
+```yml
+- name: Deploy 🚀
+  uses: JamesIves/github-pages-deploy-action@v4
+  with:
+    CNAME: example.com
+```

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -11,7 +11,8 @@ import fs from 'fs'
 const originalAction = JSON.stringify(action)
 
 jest.mock('fs', () => ({
-  existsSync: jest.fn()
+  existsSync: jest.fn(),
+  writeFileSync: jest.fn()
 }))
 
 jest.mock('@actions/core', () => ({
@@ -355,6 +356,31 @@ describe('git', () => {
       // Includes the call to generateWorktree
       expect(execute).toBeCalledTimes(11)
       expect(rmRF).toBeCalledTimes(1)
+    })
+
+    it('should execute commands with CNAME option', async () => {
+      Object.assign(action, {
+        hostname: 'github.com',
+        silent: false,
+        folder: 'assets',
+        folderPath: 'assets',
+        branch: 'branch',
+        token: '123',
+        pusher: {
+          name: 'asd',
+          email: 'as@cat'
+        },
+        CNAME: 'test.com',
+        isTest: TestFlag.NONE
+      })
+
+      await deploy(action)
+
+      // Includes the call to generateWorktree
+      expect(execute).toBeCalledTimes(11)
+      expect(rmRF).toBeCalledTimes(1)
+      expect(fs.existsSync).toBeCalledTimes(1)
+      expect(fs.writeFileSync).toBeCalledTimes(1)
     })
 
     it('should gracefully handle target folder', async () => {

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -379,7 +379,6 @@ describe('git', () => {
       // Includes the call to generateWorktree
       expect(execute).toBeCalledTimes(11)
       expect(rmRF).toBeCalledTimes(1)
-      expect(fs.existsSync).toBeCalledTimes(1)
       expect(fs.writeFileSync).toBeCalledTimes(1)
     })
 

--- a/action.yml
+++ b/action.yml
@@ -48,6 +48,10 @@ inputs:
     description: 'If you need to customize the commit message for an integration you can do so.'
     required: false
 
+  CNAME:
+    description: 'If you need to add CNAME for setting up custom domain, you can use this option. While deploying, a CNAME file will be created automatically in the deployment branch copying the address specified here.'
+    required: false
+
   clean:
     description: 'If your project generates hashed files on build you can use this option to automatically delete them from the target folder on the deployment branch with each deploy. This option is on by default and can be toggled off by setting it to false.'
     required: false

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -60,6 +60,8 @@ export interface ActionInterface {
   workspace: string
   /** GitHub tag name */
   tag?: string | null
+  /** CNAME for custom domain */
+  CNAME?: string | null
 }
 
 /** The minimum required values to run the action as a node module. */
@@ -141,7 +143,8 @@ export const action: ActionInterface = {
     : getInput('ssh-key'),
   targetFolder: getInput('target-folder'),
   workspace: process.env.GITHUB_WORKSPACE || '',
-  tag: getInput('tag')
+  tag: getInput('tag'),
+  CNAME: getInput('CNAME')
 }
 
 /** Types for the required action parameters. */

--- a/src/git.ts
+++ b/src/git.ts
@@ -14,6 +14,7 @@ import {
   isNullOrUndefined,
   suppressSensitiveInformation
 } from './util'
+import path from 'path'
 
 /* Initializes git in the workspace. */
 export async function init(action: ActionInterface): Promise<void | Error> {
@@ -189,6 +190,17 @@ export async function deploy(action: ActionInterface): Promise<Status> {
       action.workspace,
       action.silent
     )
+
+    if (action.CNAME) {
+      const cnameFilePath = path.join(
+        `${action.workspace}/${temporaryDeploymentDirectory}`,
+        'CNAME'
+      )
+
+      if (!fs.existsSync(cnameFilePath)) {
+        fs.writeFileSync(cnameFilePath, action.CNAME + '\n')
+      }
+    }
 
     if (action.singleCommit) {
       await execute(

--- a/src/git.ts
+++ b/src/git.ts
@@ -197,9 +197,9 @@ export async function deploy(action: ActionInterface): Promise<Status> {
         'CNAME'
       )
 
-      if (!fs.existsSync(cnameFilePath)) {
-        fs.writeFileSync(cnameFilePath, action.CNAME + '\n')
-      }
+      info(`Adding CNAME file…`)
+
+      fs.writeFileSync(cnameFilePath, action.CNAME + '\n')
     }
 
     if (action.singleCommit) {


### PR DESCRIPTION
## Description

Currently, to add CNAME for setting up custom domain, there is the option **[`clean`](https://github.com/JamesIves/github-pages-deploy-action#additional-build-files-)**. What the users have to do is they need to manually upload the CNAME file to the deployment branch, add the `clean` option and finally commit the changes.

This PR adds an option to specify the CNAME in the actions file directly.

```yml
- name: Deploy 🚀
  uses: JamesIves/github-pages-deploy-action@v4
  with:
    CNAME: example.com
```
The benefit is that the end users can add the CNAME more easily without manually uploading it. This will help newcomers too.

## Testing Instructions

The above command should create a `CNAME` file in the deployment branch.

## Additional Notes

I did not change any code related to `clean` option. That's why, the already created CNAME file won't be deleted even if we don't use the option `CNAME`.
> If you wish to remove these files you must go into the deployment branch directly to remove them. 

Not sure if we should change this behaviour.
