### PR TITLE
Use jest/recommended ESLint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,23 +1,15 @@
 {
-  "plugins": ["jest", "@typescript-eslint"],
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
-    "plugin:prettier/recommended"
+    "plugin:prettier/recommended",
+    "plugin:jest/recommended"
   ],
-  "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion": 9,
-    "sourceType": "module",
     "project": "./tsconfig.lint.json"
   },
-  "globals": {
-    "fetch": true
-  },
   "env": {
-    "node": true,
-    "es6": true,
-    "jest/globals": true
+    "node": true
   },
   "rules": {
     "@typescript-eslint/ban-types": [

--- a/__tests__/execute.test.ts
+++ b/__tests__/execute.test.ts
@@ -10,7 +10,7 @@ describe('execute', () => {
     stdout('hello')
     await execute('echo Montezuma', './', true)
 
-    expect(exec).toBeCalledWith('echo Montezuma', [], {
+    expect(exec).toHaveBeenCalledWith('echo Montezuma', [], {
       cwd: './',
       silent: true,
       ignoreReturnCode: false,
@@ -27,7 +27,7 @@ describe('execute', () => {
     stdout('hello')
     await execute('echo Montezuma', './', false)
 
-    expect(exec).toBeCalledWith('echo Montezuma', [], {
+    expect(exec).toHaveBeenCalledWith('echo Montezuma', [], {
       cwd: './',
       silent: false,
       ignoreReturnCode: false,

--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -55,7 +55,7 @@ describe('git', () => {
       })
 
       await init(action)
-      expect(execute).toBeCalledTimes(7)
+      expect(execute).toHaveBeenCalledTimes(7)
     })
 
     it('should catch when a function throws an error', async () => {
@@ -77,13 +77,9 @@ describe('git', () => {
         isTest: TestFlag.HAS_CHANGED_FILES
       })
 
-      try {
-        await init(action)
-      } catch (error) {
-        expect(error instanceof Error && error.message).toBe(
-          'There was an error initializing the repository: Mocked throw ❌'
-        )
-      }
+      await expect(init(action)).rejects.toThrow(
+        'There was an error initializing the repository: Mocked throw ❌'
+      )
     })
 
     it('should correctly continue when it cannot unset a git config value', async () => {
@@ -102,7 +98,7 @@ describe('git', () => {
       })
 
       await init(action)
-      expect(execute).toBeCalledTimes(7)
+      expect(execute).toHaveBeenCalledTimes(7)
     })
 
     it('should not unset git config if a user is using ssh', async () => {
@@ -124,7 +120,7 @@ describe('git', () => {
       })
 
       await init(action)
-      expect(execute).toBeCalledTimes(6)
+      expect(execute).toHaveBeenCalledTimes(6)
 
       process.env.CI = undefined
     })
@@ -145,7 +141,7 @@ describe('git', () => {
       })
 
       await init(action)
-      expect(execute).toBeCalledTimes(7)
+      expect(execute).toHaveBeenCalledTimes(7)
     })
   })
 
@@ -168,8 +164,8 @@ describe('git', () => {
       const response = await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toBeCalledTimes(14)
-      expect(rmRF).toBeCalledTimes(1)
+      expect(execute).toHaveBeenCalledTimes(14)
+      expect(rmRF).toHaveBeenCalledTimes(1)
       expect(response).toBe(Status.SUCCESS)
     })
 
@@ -191,8 +187,8 @@ describe('git', () => {
       const response = await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toBeCalledTimes(13)
-      expect(rmRF).toBeCalledTimes(1)
+      expect(execute).toHaveBeenCalledTimes(13)
+      expect(rmRF).toHaveBeenCalledTimes(1)
       expect(response).toBe(Status.SUCCESS)
     })
 
@@ -216,8 +212,8 @@ describe('git', () => {
       await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toBeCalledTimes(14)
-      expect(rmRF).toBeCalledTimes(1)
+      expect(execute).toHaveBeenCalledTimes(14)
+      expect(rmRF).toHaveBeenCalledTimes(1)
     })
 
     it('should execute commands with single commit toggled and existing branch', async () => {
@@ -240,8 +236,8 @@ describe('git', () => {
       await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toBeCalledTimes(13)
-      expect(rmRF).toBeCalledTimes(1)
+      expect(execute).toHaveBeenCalledTimes(13)
+      expect(rmRF).toHaveBeenCalledTimes(1)
     })
 
     it('should execute commands with single commit and dryRun toggled', async () => {
@@ -265,8 +261,8 @@ describe('git', () => {
       await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toBeCalledTimes(13)
-      expect(rmRF).toBeCalledTimes(1)
+      expect(execute).toHaveBeenCalledTimes(13)
+      expect(rmRF).toHaveBeenCalledTimes(1)
     })
 
     it('should not ignore CNAME or nojekyll if they exist in the deployment folder', async () => {
@@ -296,9 +292,9 @@ describe('git', () => {
       const response = await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toBeCalledTimes(14)
-      expect(rmRF).toBeCalledTimes(1)
-      expect(fs.existsSync).toBeCalledTimes(2)
+      expect(execute).toHaveBeenCalledTimes(14)
+      expect(rmRF).toHaveBeenCalledTimes(1)
+      expect(fs.existsSync).toHaveBeenCalledTimes(2)
       expect(response).toBe(Status.SUCCESS)
     })
 
@@ -328,8 +324,8 @@ describe('git', () => {
         await deploy(action)
 
         // Includes the call to generateWorktree
-        expect(execute).toBeCalledTimes(11)
-        expect(rmRF).toBeCalledTimes(1)
+        expect(execute).toHaveBeenCalledTimes(11)
+        expect(rmRF).toHaveBeenCalledTimes(1)
       })
     })
 
@@ -353,8 +349,8 @@ describe('git', () => {
       await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toBeCalledTimes(11)
-      expect(rmRF).toBeCalledTimes(1)
+      expect(execute).toHaveBeenCalledTimes(11)
+      expect(rmRF).toHaveBeenCalledTimes(1)
     })
 
     it('should gracefully handle target folder', async () => {
@@ -373,9 +369,9 @@ describe('git', () => {
 
       await deploy(action)
 
-      expect(execute).toBeCalledTimes(11)
-      expect(rmRF).toBeCalledTimes(1)
-      expect(mkdirP).toBeCalledTimes(1)
+      expect(execute).toHaveBeenCalledTimes(11)
+      expect(rmRF).toHaveBeenCalledTimes(1)
+      expect(mkdirP).toHaveBeenCalledTimes(1)
     })
 
     it('should stop early if there is nothing to commit', async () => {
@@ -393,8 +389,8 @@ describe('git', () => {
       })
 
       const response = await deploy(action)
-      expect(execute).toBeCalledTimes(11)
-      expect(rmRF).toBeCalledTimes(1)
+      expect(execute).toHaveBeenCalledTimes(11)
+      expect(rmRF).toHaveBeenCalledTimes(1)
       expect(response).toBe(Status.SKIPPED)
     })
 
@@ -416,13 +412,9 @@ describe('git', () => {
         isTest: TestFlag.HAS_CHANGED_FILES
       })
 
-      try {
-        await deploy(action)
-      } catch (error) {
-        expect(error instanceof Error && error.message).toBe(
-          'The deploy step encountered an error: Mocked throw ❌'
-        )
-      }
+      await expect(deploy(action)).rejects.toThrow(
+        'The deploy step encountered an error: Mocked throw ❌'
+      )
     })
 
     it('should execute commands if force is false and retry until limit is exceeded', async () => {
@@ -441,13 +433,9 @@ describe('git', () => {
         isTest: TestFlag.HAS_CHANGED_FILES
       })
 
-      try {
-        await deploy(action)
-      } catch (error) {
-        expect(error instanceof Error && error.message).toBe(
-          'The deploy step encountered an error: Attempt limit exceeded ❌'
-        )
-      }
+      await expect(deploy(action)).rejects.toThrow(
+        'The deploy step encountered an error: Attempt limit exceeded ❌'
+      )
     })
 
     it('should add a tag to the commit', async () => {
@@ -467,7 +455,7 @@ describe('git', () => {
       })
 
       const response = await deploy(action)
-      expect(execute).toBeCalledTimes(16)
+      expect(execute).toHaveBeenCalledTimes(16)
       expect(response).toBe(Status.SUCCESS)
     })
   })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -53,9 +53,9 @@ describe('main', () => {
       debug: true
     })
     await run(action)
-    expect(execute).toBeCalledTimes(18)
-    expect(rmRF).toBeCalledTimes(1)
-    expect(exportVariable).toBeCalledTimes(1)
+    expect(execute).toHaveBeenCalledTimes(18)
+    expect(rmRF).toHaveBeenCalledTimes(1)
+    expect(exportVariable).toHaveBeenCalledTimes(1)
   })
 
   it('should run through the commands and succeed', async () => {
@@ -73,9 +73,9 @@ describe('main', () => {
       isTest: TestFlag.HAS_CHANGED_FILES
     })
     await run(action)
-    expect(execute).toBeCalledTimes(21)
-    expect(rmRF).toBeCalledTimes(1)
-    expect(exportVariable).toBeCalledTimes(1)
+    expect(execute).toHaveBeenCalledTimes(21)
+    expect(rmRF).toHaveBeenCalledTimes(1)
+    expect(exportVariable).toHaveBeenCalledTimes(1)
   })
 
   it('should throw if an error is encountered', async () => {
@@ -92,8 +92,8 @@ describe('main', () => {
       isTest: TestFlag.HAS_CHANGED_FILES
     })
     await run(action)
-    expect(execute).toBeCalledTimes(0)
-    expect(setFailed).toBeCalledTimes(1)
-    expect(exportVariable).toBeCalledTimes(1)
+    expect(execute).toHaveBeenCalledTimes(0)
+    expect(setFailed).toHaveBeenCalledTimes(1)
+    expect(exportVariable).toHaveBeenCalledTimes(1)
   })
 })

--- a/__tests__/ssh.test.ts
+++ b/__tests__/ssh.test.ts
@@ -57,9 +57,9 @@ describe('configureSSH', () => {
 
     await configureSSH(action)
 
-    expect(execute).toBeCalledTimes(0)
-    expect(mkdirP).toBeCalledTimes(0)
-    expect(appendFileSync).toBeCalledTimes(0)
+    expect(execute).toHaveBeenCalledTimes(0)
+    expect(mkdirP).toHaveBeenCalledTimes(0)
+    expect(appendFileSync).toHaveBeenCalledTimes(0)
   })
 
   it('should configure the ssh client if a key is defined', async () => {
@@ -82,9 +82,9 @@ describe('configureSSH', () => {
 
     await configureSSH(action)
 
-    expect(execFileSync).toBeCalledTimes(1)
-    expect(exportVariable).toBeCalledTimes(2)
-    expect(execSync).toBeCalledTimes(3)
+    expect(execFileSync).toHaveBeenCalledTimes(1)
+    expect(exportVariable).toHaveBeenCalledTimes(2)
+    expect(execSync).toHaveBeenCalledTimes(3)
   })
 
   it('should not export variables if the return from ssh-agent is skewed', async () => {
@@ -107,9 +107,9 @@ describe('configureSSH', () => {
 
     await configureSSH(action)
 
-    expect(execFileSync).toBeCalledTimes(1)
-    expect(exportVariable).toBeCalledTimes(0)
-    expect(execSync).toBeCalledTimes(3)
+    expect(execFileSync).toHaveBeenCalledTimes(1)
+    expect(exportVariable).toHaveBeenCalledTimes(0)
+    expect(execSync).toHaveBeenCalledTimes(3)
   })
 
   it('should throw if something errors', async () => {
@@ -130,12 +130,8 @@ describe('configureSSH', () => {
       isTest: TestFlag.HAS_CHANGED_FILES
     })
 
-    try {
-      await configureSSH(action)
-    } catch (error) {
-      expect(error instanceof Error && error.message).toBe(
-        'The ssh client configuration encountered an error: Mocked throw ❌'
-      )
-    }
+    await expect(configureSSH(action)).rejects.toThrow(
+      'The ssh client configuration encountered an error: Mocked throw ❌'
+    )
   })
 })

--- a/__tests__/util.test.ts
+++ b/__tests__/util.test.ts
@@ -220,13 +220,9 @@ describe('util', () => {
         isTest: TestFlag.NONE
       }
 
-      try {
-        checkParameters(action)
-      } catch (e) {
-        expect(e instanceof Error && e.message).toMatch(
-          'No deployment token/method was provided. You must provide the action with either a Personal Access Token or the GitHub Token secret in order to deploy. For more details on how to use an ssh deploy key please refer to the documentation.'
-        )
-      }
+      expect(() => checkParameters(action)).toThrow(
+        'No deployment token/method was provided. You must provide the action with either a Personal Access Token or the GitHub Token secret in order to deploy. For more details on how to use an ssh deploy key please refer to the documentation.'
+      )
     })
 
     it('should fail if token is defined but it is an empty string', () => {
@@ -240,13 +236,9 @@ describe('util', () => {
         isTest: TestFlag.NONE
       }
 
-      try {
-        checkParameters(action)
-      } catch (e) {
-        expect(e instanceof Error && e.message).toMatch(
-          'No deployment token/method was provided. You must provide the action with either a Personal Access Token or the GitHub Token secret in order to deploy. For more details on how to use an ssh deploy key please refer to the documentation.'
-        )
-      }
+      expect(() => checkParameters(action)).toThrow(
+        'No deployment token/method was provided. You must provide the action with either a Personal Access Token or the GitHub Token secret in order to deploy. For more details on how to use an ssh deploy key please refer to the documentation.'
+      )
     })
 
     it('should fail if there is no branch', () => {
@@ -260,11 +252,7 @@ describe('util', () => {
         isTest: TestFlag.NONE
       }
 
-      try {
-        checkParameters(action)
-      } catch (e) {
-        expect(e instanceof Error && e.message).toMatch('Branch is required.')
-      }
+      expect(() => checkParameters(action)).toThrow('Branch is required.')
     })
 
     it('should fail if there is no folder', () => {
@@ -278,13 +266,9 @@ describe('util', () => {
         isTest: TestFlag.NONE
       }
 
-      try {
-        checkParameters(action)
-      } catch (e) {
-        expect(e instanceof Error && e.message).toMatch(
-          'You must provide the action with a folder to deploy.'
-        )
-      }
+      expect(() => checkParameters(action)).toThrow(
+        'You must provide the action with a folder to deploy.'
+      )
     })
 
     it('should fail if the folder does not exist in the tree', () => {
@@ -298,14 +282,10 @@ describe('util', () => {
         isTest: TestFlag.NONE
       }
 
-      try {
-        action.folderPath = generateFolderPath(action)
-        checkParameters(action)
-      } catch (e) {
-        expect(e instanceof Error && e.message).toMatch(
-          `The directory you're trying to deploy named notARealFolder doesn't exist. Please double check the path and any prerequisite build scripts and try again. ❗`
-        )
-      }
+      action.folderPath = generateFolderPath(action)
+      expect(() => checkParameters(action)).toThrow(
+        `The directory you're trying to deploy named notARealFolder doesn't exist. Please double check the path and any prerequisite build scripts and try again. ❗`
+      )
     })
   })
 

--- a/__tests__/worktree.error.test.ts
+++ b/__tests__/worktree.error.test.ts
@@ -13,8 +13,8 @@ describe('generateWorktree', () => {
     ;(execute as jest.Mock).mockImplementationOnce(() => {
       throw new Error('Mocked throw')
     })
-    try {
-      await generateWorktree(
+    await expect(
+      generateWorktree(
         {
           hostname: 'github.com',
           workspace: 'somewhere',
@@ -27,10 +27,8 @@ describe('generateWorktree', () => {
         'worktree',
         true
       )
-    } catch (error) {
-      expect(error instanceof Error && error.message).toBe(
-        'There was an error creating the worktree: Mocked throw ❌'
-      )
-    }
+    ).rejects.toThrow(
+      'There was an error creating the worktree: Mocked throw ❌'
+    )
   })
 })

--- a/__tests__/worktree.test.ts
+++ b/__tests__/worktree.test.ts
@@ -158,13 +158,9 @@ describe('generateWorktree', () => {
         '.git',
         'gh1'
       ])
-      expect(async () => {
-        await execute(
-          'git log --format=%s',
-          path.join(workspace, 'worktree'),
-          true
-        )
-      }).rejects.toThrow()
+      await expect(
+        execute('git log --format=%s', path.join(workspace, 'worktree'), true)
+      ).rejects.toThrow()
     })
   })
   describe('with missing branch and singleCommit', () => {
@@ -187,13 +183,9 @@ describe('generateWorktree', () => {
         path.join(workspace, 'worktree')
       )
       expect(dirEntries).toEqual(['.git'])
-      expect(async () => {
-        await execute(
-          'git log --format=%s',
-          path.join(workspace, 'worktree'),
-          true
-        )
-      }).rejects.toThrow()
+      await expect(
+        execute('git log --format=%s', path.join(workspace, 'worktree'), true)
+      ).rejects.toThrow()
     })
   })
 })


### PR DESCRIPTION
## Description

<!-- Provide a description of what your changes do. -->
We have `eslint-plugin-jest` installed, but we don't have any of its rules configured. I enabled the `jest/recommended` config to help fix some bugs I noticed in the tests. Some tests are now failing due to bugs in the implementation that are surfaced by fixed tests.

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->
Run Jest and ESLint

## Additional Notes

<!-- Anything else that will help us test the pull request. -->
Discovered in #1221