### PR TITLE
doc: `.gitignore` matches not being deployed

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The following options must be configured in order to make a deployment.
 
 | Key      | Value Information                                                                                                                                                                                                                                                                         | Type   | Required |
 | -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ | -------- |
-| `folder` | The folder in your repository that you want to deploy. If your build script compiles into a directory named `build` you'd put it here. If you wish to deploy the root directory you can place a `.` here. You can also utilize absolute file paths by prepending `~` to your folder path. | `with` | **Yes**  |
+| `folder` | The folder in your repository that you want to deploy. If your build script compiles into a directory named `build` you'd put it here. If you wish to deploy the root directory you can place a `.` here. You can also utilize absolute file paths by prepending `~` to your folder path. Note that any files/folders matching `.gitignore` entries will not be deployed. Some tools auto-generate a `.gitignore` file for build output. | `with` | **Yes**  |
 
 By default, the action does not need any token configuration and uses the provided repository scoped GitHub token to make the deployment. If you require more customization you can modify the deployment type using the following options.
 


### PR DESCRIPTION
## Description

This commit documents the influence of `.gitignore` for deployed files/folders.
