### PR TITLE
Run sponsors and integration only on original repo

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -17,6 +17,7 @@ on:
 jobs:
   # Deploys cross repo with an access token.
   integration-cross-repo-push:
+    if: github.repository == 'JamesIves/github-pages-deploy-action'
     container: node:16.13
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   generate-sponsors:
+    if: github.repository == 'JamesIves/github-pages-deploy-action'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
## Description

Run two workflows only on the original repo. Otherwise, those two actions keep failing everyday on my fork.

## Testing Instructions


## Additional Notes


