### PR TITLE
Check for fatal on every line of stderr of the git command

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -314,7 +314,7 @@ export async function deploy(action: ActionInterface): Promise<Status> {
 
         // If the push failed for any fatal reason other than being rejected,
         // there is a problem
-        if (!rejected && pushResult.stderr.split(/\n/).some(s => s.trim().startsWith('fatal:')) {
+        if (!rejected && pushResult.stderr.split(/\n/).some(s => s.trim().startsWith('fatal:'))) {
           throw new Error(pushResult.stderr)
         }
       } while (rejected)

--- a/src/git.ts
+++ b/src/git.ts
@@ -314,8 +314,9 @@ export async function deploy(action: ActionInterface): Promise<Status> {
 
         // If the push failed for any fatal reason other than being rejected,
         // there is a problem
-        if (!rejected && pushResult.stderr.trim().startsWith('fatal:'))
+        if (!rejected && pushResult.stderr.split(/\n/).some(s => s.trim().startsWith('fatal:')) {
           throw new Error(pushResult.stderr)
+        }
       } while (rejected)
     }
 


### PR DESCRIPTION
## Description

<!-- Provide a description of what your changes do. -->

Currently, we ignore git push errors and only fail when we find specific substrings in stdout or stderr starts with `fatal:`. This is insufficient to catch all errors because sometimes `fatal:` can occur on lines that are not the first. For example:

```
/usr/bin/git push --porcelain ***github.com/WATonomous/infra-config.git github-pages-deploy-action/mdm3v520a:data
remote: Write access to repository not granted.
fatal: unable to access 'https://github.com/WATonomous/infra-config.git/': The requested URL returned error: 403
Changes committed to the data branch… 📦
Running post deployment cleanup jobs… 🗑️
/usr/bin/git checkout -B github-pages-deploy-action/mdm3v520a
Reset branch 'github-pages-deploy-action/mdm3v520a'
/usr/bin/chmod -R +rw github-pages-deploy-action-temp-deployment-folder
/usr/bin/git worktree remove github-pages-deploy-action-temp-deployment-folder --force
Completed deployment successfully! ✅
```

In the output above, the `fatal:` message occurs on the second line.

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->

Run this action without giving the job `contents: write` permission. Before this change, the job will silently fail. After this change, the job will raise an exception as expected.

## Additional Notes

<!-- Anything else that will help us test the pull request. -->

The approach of ignoring all issues except some known ones is very error prone. We should instead do the opposite: ignore all known non-issues and raise an exception for everything else. But this takes more work and may be a breaking change for some use cases until we can gather a complete list of non-errors.