### PR TITLE
test: 🧪  improve integration test workflow order

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -15,12 +15,6 @@ on:
         default: 'releases/v4'
   schedule:
     - cron: 30 15 * * 0-6
-  push:
-    tags-ignore:
-      - '*.*'
-    branches:
-      - releases/v4
-
 
 jobs:
   # Deploys cross repo with an access token.

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,23 +1,11 @@
 name: Integration Tests 🧪
 on:
   workflow_call:
-    inputs:
-      branch:
-        description: 'Specifies the branch which the integration tests should run on.'
-        required: true
-        default: 'releases/v4'
-        type: string
   workflow_dispatch:
-    inputs:
-      branch:
-        description: 'Specifies the branch which the integration tests should run on.'
-        required: true
-        default: 'releases/v4'
   schedule:
     - cron: 30 15 * * 0-6
 
 jobs:
-  # Deploys cross repo with an access token.
   integration-cross-repo-push:
     container: node:16.13
     runs-on: ubuntu-latest
@@ -42,7 +30,6 @@ jobs:
           clean: true
           silent: true
 
-  # Deploys using checkout@v1 with an ACCESS_TOKEN.
   integration-checkout-v1:
     needs: integration-cross-repo-push
     runs-on: ubuntu-latest
@@ -64,8 +51,8 @@ jobs:
         uses: dawidd6/action-delete-branch@v3.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branches: gh-pages
 
-  # Deploys using checkout@v2 with a GITHUB_TOKEN.
   integration-checkout-v2:
     needs: integration-checkout-v1
     runs-on: ubuntu-latest
@@ -88,6 +75,36 @@ jobs:
         uses: dawidd6/action-delete-branch@v3.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branches: gh-pages
+
+  integration-root-folder:
+    needs: integration-checkout-v1
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Echo
+        working-directory: integration
+        run: |
+          echo "Here"
+
+      - name: Build and Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: .
+          target-folder: cat/montezuma5
+          silent: true
+          git-config-name: Montezuma
+          git-config-email: montezuma@jamesiv.es
+
+      - name: Cleanup Generated Branch
+        uses: dawidd6/action-delete-branch@v3.1.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branches: gh-pages
 
   # Deploys using a container that requires you to install rsync.
   integration-container:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,5 +1,12 @@
 name: Integration Tests 🧪
 on:
+  workflow_call:
+    inputs:
+      branch:
+        description: 'Specifies the branch which the integration tests should run on.'
+        required: true
+        default: 'releases/v4'
+        type: string
   workflow_dispatch:
     inputs:
       branch:
@@ -13,6 +20,7 @@ on:
       - '*.*'
     branches:
       - releases/v4
+
 
 jobs:
   # Deploys cross repo with an access token.

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -12,7 +12,14 @@ jobs:
     steps:
       - uses: nowactions/update-majorver@v1.1.2
 
+  call-integration-workflow:
+    needs: update-majorver
+    uses: ./.github/workflows/integration.yml
+    with:
+      branch: 'releases/v4'
+
   update-registries:
+    needs: call-integration-workflow
     name: Publish to Registries 📦
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: nowactions/update-majorver@v1.1.2
 
   call-integration-workflow:
+    name: Verify Major Tag Release 🚀
     needs: update-majorver
     uses: ./.github/workflows/integration.yml
     with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -13,11 +13,9 @@ jobs:
       - uses: nowactions/update-majorver@v1.1.2
 
   call-integration-workflow:
-    name: Verify Major Tag Release 🚀
+    name: Verify Major Tag 🚀
     needs: update-majorver
     uses: ./.github/workflows/integration.yml
-    with:
-      branch: 'releases/v4'
 
   update-registries:
     needs: call-integration-workflow


### PR DESCRIPTION
## Description

<!-- Provide a description of what your changes do. -->

#1697 went missed during a release cycle because the integration tests ran _before_ the major tag version tag updated. This change adjusts the flow so the integration tests run on a CRON, but also _after_ the major tag is made using workflow_call. This ensures that the tests fail immediately without users having to report an issue like this, or before the scheduled tests find the issue. 

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->

N/A

## Additional Notes

<!-- Anything else that will help us test the pull request. -->

N/A