### PR TITLE
fix: :bug: Add the temp directory created to the safe directory list

### DIFF
--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -167,7 +167,7 @@ describe('git', () => {
       const response = await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toHaveBeenCalledTimes(14)
+      expect(execute).toHaveBeenCalledTimes(15)
       expect(rmRF).toHaveBeenCalledTimes(1)
       expect(response).toBe(Status.SUCCESS)
     })
@@ -190,7 +190,7 @@ describe('git', () => {
       const response = await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toHaveBeenCalledTimes(13)
+      expect(execute).toHaveBeenCalledTimes(14)
       expect(rmRF).toHaveBeenCalledTimes(1)
       expect(response).toBe(Status.SUCCESS)
     })
@@ -215,7 +215,7 @@ describe('git', () => {
       await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toHaveBeenCalledTimes(14)
+      expect(execute).toHaveBeenCalledTimes(15)
       expect(rmRF).toHaveBeenCalledTimes(1)
     })
 
@@ -264,7 +264,7 @@ describe('git', () => {
       await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toHaveBeenCalledTimes(13)
+      expect(execute).toHaveBeenCalledTimes(14)
       expect(rmRF).toHaveBeenCalledTimes(1)
     })
 
@@ -295,7 +295,7 @@ describe('git', () => {
       const response = await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toHaveBeenCalledTimes(14)
+      expect(execute).toHaveBeenCalledTimes(15)
       expect(rmRF).toHaveBeenCalledTimes(1)
       expect(fs.existsSync).toHaveBeenCalledTimes(2)
       expect(response).toBe(Status.SUCCESS)
@@ -327,7 +327,7 @@ describe('git', () => {
         await deploy(action)
 
         // Includes the call to generateWorktree
-        expect(execute).toHaveBeenCalledTimes(11)
+        expect(execute).toHaveBeenCalledTimes(12)
         expect(rmRF).toHaveBeenCalledTimes(1)
       })
     })
@@ -352,7 +352,7 @@ describe('git', () => {
       await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toHaveBeenCalledTimes(11)
+      expect(execute).toHaveBeenCalledTimes(12)
       expect(rmRF).toHaveBeenCalledTimes(1)
     })
 
@@ -372,7 +372,7 @@ describe('git', () => {
 
       await deploy(action)
 
-      expect(execute).toHaveBeenCalledTimes(11)
+      expect(execute).toHaveBeenCalledTimes(12)
       expect(rmRF).toHaveBeenCalledTimes(1)
       expect(mkdirP).toHaveBeenCalledTimes(1)
     })
@@ -392,7 +392,7 @@ describe('git', () => {
       })
 
       const response = await deploy(action)
-      expect(execute).toHaveBeenCalledTimes(11)
+      expect(execute).toHaveBeenCalledTimes(12)
       expect(rmRF).toHaveBeenCalledTimes(1)
       expect(response).toBe(Status.SKIPPED)
     })
@@ -466,7 +466,7 @@ describe('git', () => {
       })
 
       const response = await deploy(action)
-      expect(execute).toHaveBeenCalledTimes(16)
+      expect(execute).toHaveBeenCalledTimes(17)
       expect(response).toBe(Status.SUCCESS)
     })
   })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -53,7 +53,7 @@ describe('main', () => {
       debug: true
     })
     await run(action)
-    expect(execute).toHaveBeenCalledTimes(18)
+    expect(execute).toHaveBeenCalledTimes(19)
     expect(rmRF).toHaveBeenCalledTimes(1)
     expect(exportVariable).toHaveBeenCalledTimes(1)
   })
@@ -73,7 +73,7 @@ describe('main', () => {
       isTest: TestFlag.HAS_CHANGED_FILES
     })
     await run(action)
-    expect(execute).toHaveBeenCalledTimes(21)
+    expect(execute).toHaveBeenCalledTimes(22)
     expect(rmRF).toHaveBeenCalledTimes(1)
     expect(exportVariable).toHaveBeenCalledTimes(1)
   })

--- a/src/worktree.ts
+++ b/src/worktree.ts
@@ -128,6 +128,19 @@ export async function generateWorktree(
           action.silent
         )
       }
+
+      /**
+       * Ensure that the workspace is a safe directory.
+       */
+      try {
+        await execute(
+          `git config --global --add safe.directory "${action.workspace}/${worktreedir}"`,
+          action.workspace,
+          action.silent
+        )
+      } catch {
+        info('Unable to set worktree temp directory as a safe directory…')
+      }
     }
   } catch (error) {
     throw new Error(


### PR DESCRIPTION
## Description

<!-- Provide a description of what your changes do. -->

Adds the temp workflow directory to the safe list of directories. A deployment failure can occur here depending on the type of files moved around by the workflow, and as such we need to mark this directory as safe too to prevent dubious ownership.

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->

This has been validated on a test branch. I have also added a replicate PR in the integration test to validate root level deployments to ensure they continue to work. It doesn't repro this bug, but it's something at least. 

## Additional Notes

<!-- Anything else that will help us test the pull request. -->

Closes #1694 