### PR TITLE
fix: enable rsync mkpath to be backwards compatible

### DIFF
--- a/src/git.ts
+++ b/src/git.ts
@@ -12,7 +12,8 @@ import {generateWorktree} from './worktree'
 import {
   extractErrorMessage,
   isNullOrUndefined,
-  suppressSensitiveInformation
+  suppressSensitiveInformation,
+  getRsyncVersion
 } from './util'
 
 /**
@@ -110,6 +111,8 @@ export async function deploy(action: ActionInterface): Promise<Status> {
   const temporaryDeploymentBranch = `github-pages-deploy-action/${Math.random()
     .toString(36)
     .substr(2, 9)}`
+  const rsyncVersion = getRsyncVersion();
+  const isMkpathSupported = rsyncVersion >= '3.2.3';
 
   info('Starting to commit changes…')
 
@@ -166,7 +169,7 @@ export async function deploy(action: ActionInterface): Promise<Status> {
       Allows the user to specify the root if '.' is provided.
       rsync is used to prevent file duplication. */
     await execute(
-      `rsync -q -av --checksum --progress ${action.targetFolder ? '--mkpath' : ''} ${action.folderPath}/. ${
+      `rsync -q -av --checksum --progress ${isMkpathSupported && action.targetFolder ? '--mkpath' : ''} ${action.folderPath}/. ${
         action.targetFolder
           ? `${temporaryDeploymentDirectory}/${action.targetFolder}`
           : temporaryDeploymentDirectory

--- a/src/git.ts
+++ b/src/git.ts
@@ -111,8 +111,8 @@ export async function deploy(action: ActionInterface): Promise<Status> {
   const temporaryDeploymentBranch = `github-pages-deploy-action/${Math.random()
     .toString(36)
     .substr(2, 9)}`
-  const rsyncVersion = getRsyncVersion();
-  const isMkpathSupported = rsyncVersion >= '3.2.3';
+  const rsyncVersion = getRsyncVersion()
+  const isMkpathSupported = rsyncVersion >= '3.2.3'
 
   info('Starting to commit changes…')
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,6 @@
-import {isDebug, warning} from '@actions/core'
-import {existsSync} from 'fs'
+import { isDebug, warning } from '@actions/core'
+import { execSync } from 'child_process'
+import { existsSync } from 'fs'
 import path from 'path'
 import {
   ActionInterface,
@@ -140,3 +141,16 @@ export const extractErrorMessage = (error: unknown): string =>
  */
 export const stripProtocolFromUrl = (url: string): string =>
   url.replace(/^(?:https?:\/\/)?(?:www\.)?/i, '').split('/')[0]
+
+/**
+ * Gets the rsync version.
+ */
+export function getRsyncVersion(): string {
+  try {
+    const versionOutput = execSync('rsync --version').toString();
+    const versionMatch = versionOutput.match(/rsync\s+version\s+(\d+\.\d+\.\d+)/);
+    return versionMatch ? versionMatch[1] : '';
+  } catch (error) {
+    return '';
+  }
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,6 @@
-import { isDebug, warning } from '@actions/core'
-import { execSync } from 'child_process'
-import { existsSync } from 'fs'
+import {isDebug, warning} from '@actions/core'
+import {execSync} from 'child_process'
+import {existsSync} from 'fs'
 import path from 'path'
 import {
   ActionInterface,
@@ -147,12 +147,14 @@ export const stripProtocolFromUrl = (url: string): string =>
  */
 export function getRsyncVersion(): string {
   try {
-    const versionOutput = execSync('rsync --version').toString();
-    const versionMatch = versionOutput.match(/rsync\s+version\s+(\d+\.\d+\.\d+)/);
-    return versionMatch ? versionMatch[1] : '';
+    const versionOutput = execSync('rsync --version').toString()
+    const versionMatch = versionOutput.match(
+      /rsync\s+version\s+(\d+\.\d+\.\d+)/
+    )
+    return versionMatch ? versionMatch[1] : ''
   } catch (error) {
-    console.error(error);
-    
-    return '';
+    console.error(error)
+
+    return ''
   }
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -151,6 +151,8 @@ export function getRsyncVersion(): string {
     const versionMatch = versionOutput.match(/rsync\s+version\s+(\d+\.\d+\.\d+)/);
     return versionMatch ? versionMatch[1] : '';
   } catch (error) {
+    console.error(error);
+    
     return '';
   }
 }


### PR DESCRIPTION
## Description

<!-- Provide a description of what your changes do. -->

Check the available version of rsync, allowing older Ubuntu versions to continue to use the action.

## Testing Instructions

<!-- Give us step by step instructions on how to test your changes. -->

N/A

## Additional Notes

<!-- Anything else that will help us test the pull request. -->

Closes #1753 
