### PR TITLE
fix unexpected input attempt-limit warning annotation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -90,6 +90,11 @@ inputs:
     description: 'Silences the action output preventing it from displaying git messages.'
     required: false
 
+  attempt-limit:
+    description: 'How many rebase attempts to make before suspending the job. This option defaults to `3` and may be useful to increase when there are multiple deployments in a single branch.'
+    required: false
+    default: 3
+
 outputs:
   deployment-status:
     description: 'The status of the deployment that indicates if the run failed or passed. Possible outputs include: success|failed|skipped'


### PR DESCRIPTION
## Description

The github actions UI produces a warning annotation if an input that isn't in the `action.yml` is passed to the action, see https://github.com/databasedav/haalka/actions/runs/13221401713/job/36907191087
```
Warning: Unexpected input(s) 'attempt-limit', valid inputs are ['ssh-key', 'token', 'branch', 'folder', 'target-folder', 'commit-message', 'clean', 'clean-exclude', 'dry-run', 'force', 'git-config-name', 'git-config-email', 'repository-name', 'tag', 'single-commit', 'silent']
```