### PR TITLE
To spot new files and folders, add --all needed before checking for changes

### DIFF
--- a/__tests__/git.test.ts
+++ b/__tests__/git.test.ts
@@ -327,7 +327,7 @@ describe('git', () => {
         await deploy(action)
 
         // Includes the call to generateWorktree
-        expect(execute).toHaveBeenCalledTimes(12)
+        expect(execute).toHaveBeenCalledTimes(13)
         expect(rmRF).toHaveBeenCalledTimes(1)
       })
     })
@@ -352,7 +352,7 @@ describe('git', () => {
       await deploy(action)
 
       // Includes the call to generateWorktree
-      expect(execute).toHaveBeenCalledTimes(12)
+      expect(execute).toHaveBeenCalledTimes(13)
       expect(rmRF).toHaveBeenCalledTimes(1)
     })
 
@@ -372,7 +372,7 @@ describe('git', () => {
 
       await deploy(action)
 
-      expect(execute).toHaveBeenCalledTimes(12)
+      expect(execute).toHaveBeenCalledTimes(13)
       expect(rmRF).toHaveBeenCalledTimes(1)
       expect(mkdirP).toHaveBeenCalledTimes(1)
     })
@@ -392,7 +392,7 @@ describe('git', () => {
       })
 
       const response = await deploy(action)
-      expect(execute).toHaveBeenCalledTimes(12)
+      expect(execute).toHaveBeenCalledTimes(13)
       expect(rmRF).toHaveBeenCalledTimes(1)
       expect(response).toBe(Status.SKIPPED)
     })

--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -53,7 +53,7 @@ describe('main', () => {
       debug: true
     })
     await run(action)
-    expect(execute).toHaveBeenCalledTimes(19)
+    expect(execute).toHaveBeenCalledTimes(20)
     expect(rmRF).toHaveBeenCalledTimes(1)
     expect(exportVariable).toHaveBeenCalledTimes(1)
   })

--- a/src/git.ts
+++ b/src/git.ts
@@ -217,6 +217,13 @@ export async function deploy(action: ActionInterface): Promise<Status> {
         ? `git diff origin/${action.branch}`
         : `git status --porcelain`
 
+    // Commits to GitHub.
+    await execute(
+      `git add --all .`,
+      `${action.workspace}/${temporaryDeploymentDirectory}`,
+      action.silent
+    )
+
     info(`Checking if there are files to commit…`)
 
     const hasFilesToCommit =
@@ -239,12 +246,6 @@ export async function deploy(action: ActionInterface): Promise<Status> {
       return Status.SKIPPED
     }
 
-    // Commits to GitHub.
-    await execute(
-      `git add --all .`,
-      `${action.workspace}/${temporaryDeploymentDirectory}`,
-      action.silent
-    )
     await execute(
       `git checkout -b ${temporaryDeploymentBranch}`,
       `${action.workspace}/${temporaryDeploymentDirectory}`,


### PR DESCRIPTION
## Description

The action doesn't sucessfully spot new files and folders - found when using target-folder when adding a second workflow.
## Testing Instructions

In an existing flow, add a second workflow that adds new content.

## Additional Notes

Surprised this hasn't been hit before!
