### PR TITLE
Fix integration tests failing on Debian Buster EOL (#1918)

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   integration-cross-repo-push:
-    container: node:16.13
+    container: node:22
     runs-on: ubuntu-latest
     steps:
       - name: Install Container Dependencies 📚
@@ -82,7 +82,7 @@ jobs:
     needs: integration-checkout-v2
     runs-on: ubuntu-latest
     container:
-      image: ruby:2.6
+      image: ruby:3.3
       env:
         LANG: C.UTF-8
     steps:


### PR DESCRIPTION
This pull request updates the integration workflow configuration to use newer versions of the Node and Ruby containers, ensuring compatibility with current dependencies and improved security.

Container version upgrades:

* Updated the `integration-cross-repo-push` job to use the `node:22` container instead of `node:16.13` in `.github/workflows/integration.yml`.
* Updated the `integration-checkout-v2` job to use the `ruby:3.3` container instead of `ruby:2.6` in `.github/workflows/integration.yml`.