### PR TITLE
Update GitHub SSH known host keys

### DIFF
--- a/__tests__/ssh.test.ts
+++ b/__tests__/ssh.test.ts
@@ -7,6 +7,9 @@ import {execute} from '../src/execute.js'
 import {configureSSH} from '../src/ssh.js'
 
 const originalAction = JSON.stringify(action)
+const expectedGitHubKnownHostRsa = `\ngithub.com ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=\n`
+const expectedGitHubKnownHostEcdsa = `\ngithub.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=\n`
+const expectedGitHubKnownHostEd25519 = `\ngithub.com ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl\n`
 
 jest.mock('fs', () => ({
   appendFileSync: jest.fn(),
@@ -75,6 +78,23 @@ describe('configureSSH', () => {
     expect(execFileSync).toHaveBeenCalledTimes(1)
     expect(exportVariable).toHaveBeenCalledTimes(2)
     expect(execSync).toHaveBeenCalledTimes(3)
+    expect(appendFileSync).toHaveBeenCalledTimes(3)
+expect(appendFileSync).toHaveBeenCalledWith(
+  `${process.env['HOME']}/.ssh/known_hosts`,
+  expectedGitHubKnownHostRsa
+)
+expect(appendFileSync).toHaveBeenCalledWith(
+  `${process.env['HOME']}/.ssh/known_hosts`,
+  expectedGitHubKnownHostEcdsa
+)
+expect(appendFileSync).toHaveBeenCalledWith(
+  `${process.env['HOME']}/.ssh/known_hosts`,
+  expectedGitHubKnownHostEd25519
+)
+expect(appendFileSync).not.toHaveBeenCalledWith(
+  expect.any(String),
+  expect.stringContaining('ssh-dss')
+)
   })
 
   it('should not export variables if the return from ssh-agent is skewed', async () => {

--- a/src/ssh.ts
+++ b/src/ssh.ts
@@ -14,16 +14,18 @@ export async function configureSSH(action: ActionInterface): Promise<void> {
       const sshDirectory = `${process.env['HOME']}/.ssh`
       const sshKnownHostsDirectory = `${sshDirectory}/known_hosts`
 
-      // SSH fingerprints provided by GitHub: https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/githubs-ssh-key-fingerprints
-      const sshGitHubKnownHostRsa = `\n${action.hostname} ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEAq2A7hRGmdnm9tUDbO9IDSwBK6TbQa+PXYPCPy6rbTrTtw7PHkccKrpp0yVhp5HdEIcKr6pLlVDBfOLX9QUsyCOV0wzfjIJNlGEYsdlLJizHhbn2mUjvSAHQqZETYP81eFzLQNnPHt4EVVUh7VfDESU84KezmD5QlWpXLmvU31/yMf+Se8xhHTvKSCZIFImWwoG6mbUoWf9nzpIoaSjB+weqqUUmpaaasXVal72J+UX2B+2RPW3RcT0eOzQgqlJL3RKrTJvdsjE3JEAvGq3lGHSZXy28G3skua2SmVi/w4yCE6gbODqnTWlg7+wC604ydGXA8VJiS5ap43JXiUFFAaQ==\n`
-      const sshGitHubKnownHostDss = `\n${action.hostname} ssh-dss AAAAB3NzaC1kc3MAAACBANGFW2P9xlGU3zWrymJgI/lKo//ZW2WfVtmbsUZJ5uyKArtlQOT2+WRhcg4979aFxgKdcsqAYW3/LS1T2km3jYW/vr4Uzn+dXWODVk5VlUiZ1HFOHf6s6ITcZvjvdbp6ZbpM+DuJT7Bw+h5Fx8Qt8I16oCZYmAPJRtu46o9C2zk1AAAAFQC4gdFGcSbp5Gr0Wd5Ay/jtcldMewAAAIATTgn4sY4Nem/FQE+XJlyUQptPWMem5fwOcWtSXiTKaaN0lkk2p2snz+EJvAGXGq9dTSWHyLJSM2W6ZdQDqWJ1k+cL8CARAqL+UMwF84CR0m3hj+wtVGD/J4G5kW2DBAf4/bqzP4469lT+dF2FRQ2L9JKXrCWcnhMtJUvua8dvnwAAAIB6C4nQfAA7x8oLta6tT+oCk2WQcydNsyugE8vLrHlogoWEicla6cWPk7oXSspbzUcfkjN3Qa6e74PhRkc7JdSdAlFzU3m7LMkXo1MHgkqNX8glxWNVqBSc0YRdbFdTkL0C6gtpklilhvuHQCdbgB3LBAikcRkDp+FCVkUgPC/7Rw==\n`
-
+      // GitHub.com SSH host keys:
+// https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints
+const sshGitHubKnownHostRsa = `\n${action.hostname} ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCj7ndNxQowgcQnjshcLrqPEiiphnt+VTTvDP6mHBL9j1aNUkY4Ue1gvwnGLVlOhGeYrnZaMgRK6+PKCUXaDbC7qtbW8gIkhL7aGCsOr/C56SJMy/BCZfxd1nWzAOxSDPgVsmerOBYfNqltV9/hWCqBywINIR+5dIg6JTJ72pcEpEjcYgXkE2YEFXV1JHnsKgbLWNlhScqb2UmyRkQyytRLtL+38TGxkxCflmO+5Z8CSSNY7GidjMIZ7Q4zMjA2n1nGrlTDkzwDCsw+wqFPGQA179cnfGWOWRVruj16z6XyvxvjJwbz0wQZ75XK5tKSb7FNyeIEs4TT4jk+S4dhPeAUC5y+bDYirYgM4GC7uEnztnZyaVWQ7B381AK4Qdrwt51ZqExKbQpTUNn+EjqoTwvqNj4kqx5QUCI0ThS/YkOxJCXmPUWZbhjpCg56i+2aB6CmK2JGhn57K5mj0MNdBXA4/WnwH6XoPWJzK5Nyu2zB3nAZp+S5hpQs+p1vN1/wsjk=\n`
+const sshGitHubKnownHostEcdsa = `\n${action.hostname} ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg=\n`
+const sshGitHubKnownHostEd25519 = `\n${action.hostname} ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOMqqnkVzrm0SdG6UOoqKLsabgH5C9okWi0dh2l9GKJl\n`
       info(`Configuring SSH client… 🔑`)
 
       await mkdirP(sshDirectory)
 
       appendFileSync(sshKnownHostsDirectory, sshGitHubKnownHostRsa)
-      appendFileSync(sshKnownHostsDirectory, sshGitHubKnownHostDss)
+appendFileSync(sshKnownHostsDirectory, sshGitHubKnownHostEcdsa)
+appendFileSync(sshKnownHostsDirectory, sshGitHubKnownHostEd25519)
 
       // Initializes SSH agent.
       const agentOutput = execFileSync('ssh-agent').toString().split('\n')


### PR DESCRIPTION
## Description

This updates the GitHub SSH known-host entries used during SSH setup.

The action now uses GitHub's current RSA, ECDSA, and Ed25519 host keys from the official SSH fingerprint documentation, and no longer writes the DSA/DSS entry.

GitHub SSH fingerprint docs:
https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints

## Testing Instructions

- Verified the known-host entries against GitHub's current SSH fingerprint documentation.
- Added focused unit test assertions for the known-host entries written by `configureSSH`.
- Not run locally; CI should run the test suite.

## Additional Notes

This keeps the existing behavior shape and only updates the known-host key material.